### PR TITLE
Walmart -> Formidable

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
 The MIT License (MIT)
 
+Copyright (c) 2016 Formidable Labs, Inc.
+
 Copyright (c) 2015 Keith Cirkel
 
 Copyright (c) 2015 Eric Baer <me@ericbaer.com>

--- a/README.md
+++ b/README.md
@@ -1,31 +1,25 @@
-<h1 align="center">eslint-config-walmart</h1>
+# eslint-config-formidable
+#### A composable set of ESLint configurations.
+<a title='npm version' href="https://npmjs.org/package/eslint-config-walmart">
+  <img src='http://img.shields.io/npm/v/eslint-config-walmart.svg' />
+</a>
+<a title='License' href="https://opensource.org/licenses/MIT">
+  <img src='https://img.shields.io/badge/license-MIT-blue.svg' />
+</a>
+<a title='Build Status' href='https://travis-ci.org/walmartlabs/eslint-config-walmart'>
+  <img src='https://api.travis-ci.org/walmartlabs/eslint-config-walmart.svg?branch=master' />
+</a>
 
-<p align="center">
-  <a title='npm version' href="https://npmjs.org/package/eslint-config-walmart">
-    <img src='http://img.shields.io/npm/v/eslint-config-walmart.svg' />
-  </a>
-  <a title='License' href="https://opensource.org/licenses/MIT">
-    <img src='https://img.shields.io/badge/license-MIT-blue.svg' />
-  </a>
-  <a title='Build Status' href='https://travis-ci.org/walmartlabs/eslint-config-walmart'>
-    <img src='https://api.travis-ci.org/walmartlabs/eslint-config-walmart.svg?branch=master' />
-  </a>
-</p>
+_______
 
-<h4 align="center">
-  A composable set of ESLint configurations.
-</h4>
-
-***
-
-This project is the maintained offshoot of [eslint-config-defaults](https://github.com/walmartlabs/eslint-config-defaults) with just the Walmart Labs-flavored rules included. It is `eslint@2+`-compatible and actively maintained (with love) by the friendly folks at Walmart Labs.
+This project is based on [eslint-config-walmart](https://github.com/walmartlabs/eslint-config-walmart). It is `eslint@2+`-compatible and maintained by Formidable.
 
 ## Installation
 
 Install this config package and ESLint:
 
 ```bash
-$ npm install --save-dev eslint eslint-config-walmart
+$ npm install --save-dev eslint eslint-config-formidable
 ```
 
 ## Usage
@@ -34,22 +28,22 @@ $ npm install --save-dev eslint eslint-config-walmart
 
 This package includes the following complete and ready to use configurations:
 
-- `walmart` - ES6 config
-- `walmart/configurations/off` - Disable all rules (ESLint's default at 1.0.0+)
-- `walmart/configurations/es5-browser` - ES5 + browser
-- `walmart/configurations/es5-node` - ES5 + node < 4.x
-- `walmart/configurations/es5-test` - ES5 + test
-- `walmart/configurations/es5` - ES5 config
-- `walmart/configurations/es6-browser` - ES6 + browser
-- `walmart/configurations/es6-node` - ES6 + node 4.x
-- `walmart/configurations/es6-react-test` - ES6 + react + test
-- `walmart/configurations/es6-react` - ES6 + react
-- `walmart/configurations/es6-test` - ES6 + test
-- `walmart/configurations/es6` - ES6 config
+- `formidable` - ES6 config
+- `formidable/configurations/off` - Disable all rules (ESLint's default at 1.0.0+)
+- `formidable/configurations/es5-browser` - ES5 + browser
+- `formidable/configurations/es5-node` - ES5 + node < 4.x
+- `formidable/configurations/es5-test` - ES5 + test
+- `formidable/configurations/es5` - ES5 config
+- `formidable/configurations/es6-browser` - ES6 + browser
+- `formidable/configurations/es6-node` - ES6 + node 4.x
+- `formidable/configurations/es6-react-test` - ES6 + react + test
+- `formidable/configurations/es6-react` - ES6 + react
+- `formidable/configurations/es6-test` - ES6 + test
+- `formidable/configurations/es6` - ES6 config
 
 ###### Dependencies
 
-- Any config (`walmart/configurations/<suffix>`) - [eslint-plugin-filenames](https://github.com/selaux/eslint-plugin-filenames)
+- Any config (`formidable/configurations/<suffix>`) - [eslint-plugin-filenames](https://github.com/selaux/eslint-plugin-filenames)
 - Any React config (`<prefix>-react`) - [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react), [babel-eslint](https://github.com/babel/babel-eslint)
 - Any ES-next config (`es6-<suffix>`) - [babel-eslint](https://github.com/babel/babel-eslint)
 
@@ -60,13 +54,13 @@ more details about how shareable configs work, see the
 ```yaml
 ---
 "extends":
-  - "walmart"
+  - "formidable"
 ```
 
 ```yaml
 ---
 "extends":
-  - "walmart/configurations/es6-browser"
+  - "formidable/configurations/es6-browser"
 ```
 
 **NOTE:** Extending multiple complete configs can cause unexpected results, if you need to do this you should consider a piecemeal config as explained below. See https://github.com/walmartlabs/eslint-config-defaults/issues/38 for details.
@@ -80,9 +74,9 @@ ESLint configuration is broken apart in `./rules` containing ESLint's rules and 
 ```yaml
 ---
 "extends":
-  - "walmart/rules/eslint/best-practices/on",
-  - "walmart/rules/eslint/es6/off"
-  - "walmart/rules/eslint/node/off"
+  - "formidable/rules/eslint/best-practices/on",
+  - "formidable/rules/eslint/es6/off"
+  - "formidable/rules/eslint/node/off"
 
 "env":
   "phantom": true

--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
 # eslint-config-formidable
 #### A composable set of ESLint configurations.
-<a title='npm version' href="https://npmjs.org/package/eslint-config-walmart">
-  <img src='http://img.shields.io/npm/v/eslint-config-walmart.svg' />
-</a>
-<a title='License' href="https://opensource.org/licenses/MIT">
-  <img src='https://img.shields.io/badge/license-MIT-blue.svg' />
-</a>
-<a title='Build Status' href='https://travis-ci.org/walmartlabs/eslint-config-walmart'>
-  <img src='https://api.travis-ci.org/walmartlabs/eslint-config-walmart.svg?branch=master' />
-</a>
-
 _______
 
 This project is based on [eslint-config-walmart](https://github.com/walmartlabs/eslint-config-walmart). It is `eslint@2+`-compatible and maintained by Formidable.
@@ -19,7 +9,7 @@ This project is based on [eslint-config-walmart](https://github.com/walmartlabs/
 Install this config package and ESLint:
 
 ```bash
-$ npm install --save-dev eslint eslint-config-formidable
+$ npm install --save-dev eslint@2.10.2 eslint-config-formidable
 ```
 
 ## Usage

--- a/configurations/es5-browser.js
+++ b/configurations/es5-browser.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "extends": "walmart/configurations/es5",
+  "extends": "formidable/configurations/es5",
   "env": {
     "browser": true
   }

--- a/configurations/es5-node.js
+++ b/configurations/es5-node.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   "extends": [
-    "walmart/configurations/es5",
-    "walmart/rules/eslint/node/on"
+    "formidable/configurations/es5",
+    "formidable/rules/eslint/node/on"
   ],
   "env": {
     "node": true

--- a/configurations/es5-test.js
+++ b/configurations/es5-test.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   "extends": [
-    "walmart/configurations/es5"
+    "formidable/configurations/es5"
   ],
   "env": {
     "mocha": true

--- a/configurations/es5.js
+++ b/configurations/es5.js
@@ -2,14 +2,14 @@
 
 module.exports = {
   "extends": [
-    "walmart/rules/eslint/best-practices/on",
-    "walmart/rules/eslint/errors/on",
-    "walmart/rules/eslint/es6/off",
-    "walmart/rules/eslint/node/off",
-    "walmart/rules/eslint/strict/on",
-    "walmart/rules/eslint/style/on",
-    "walmart/rules/eslint/variables/on",
-    "walmart/rules/filenames/on"
+    "formidable/rules/eslint/best-practices/on",
+    "formidable/rules/eslint/errors/on",
+    "formidable/rules/eslint/es6/off",
+    "formidable/rules/eslint/node/off",
+    "formidable/rules/eslint/strict/on",
+    "formidable/rules/eslint/style/on",
+    "formidable/rules/eslint/variables/on",
+    "formidable/rules/filenames/on"
   ],
   "parserOptions": {
     "ecmaVersion": 5,

--- a/configurations/es6-browser.js
+++ b/configurations/es6-browser.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "extends": "walmart/configurations/es6",
+  "extends": "formidable/configurations/es6",
   "env": {
     "browser": true
   }

--- a/configurations/es6-node-test.js
+++ b/configurations/es6-node-test.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   "extends": [
-    "walmart/configurations/es6-node"
+    "formidable/configurations/es6-node"
   ],
   "env": {
     "mocha": true,

--- a/configurations/es6-node.js
+++ b/configurations/es6-node.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   "extends": [
-    "walmart/configurations/es6",
-    "walmart/configurations/rules/eslint/node/on"
+    "formidable/configurations/es6",
+    "formidable/configurations/rules/eslint/node/on"
   ],
   "env": {
     "node": true

--- a/configurations/es6-react-test.js
+++ b/configurations/es6-react-test.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "extends": "walmart/configurations/es6-react",
+  "extends": "formidable/configurations/es6-react",
   "env": {
     "mocha": true,
     "phantomjs": true

--- a/configurations/es6-react.js
+++ b/configurations/es6-react.js
@@ -3,8 +3,8 @@
 module.exports = {
   "parser": "babel-eslint",
   "extends": [
-    "walmart/configurations/es6",
-    "walmart/rules/react/on"
+    "formidable/configurations/es6",
+    "formidable/rules/react/on"
   ],
   "parserOptions": {
     "ecmaFeatures": {

--- a/configurations/es6-test.js
+++ b/configurations/es6-test.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "extends": "walmart/configurations/es6",
+  "extends": "formidable/configurations/es6",
   "env": {
     "mocha": true,
     "phantomjs": true

--- a/configurations/es6.js
+++ b/configurations/es6.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   "extends": [
-    "walmart/configurations/es5",
-    "walmart/rules/eslint/es6/on"
+    "formidable/configurations/es5",
+    "formidable/rules/eslint/es6/on"
   ],
   "parser": "babel-eslint",
   "parserOptions": {

--- a/configurations/off.js
+++ b/configurations/off.js
@@ -2,13 +2,13 @@
 
 module.exports = {
   "extends": [
-    "walmart/rules/eslint/best-practices/off",
-    "walmart/rules/eslint/errors/off",
-    "walmart/rules/eslint/es6/off",
-    "walmart/rules/eslint/node/off",
-    "walmart/rules/eslint/strict/off",
-    "walmart/rules/eslint/style/off",
-    "walmart/rules/eslint/variables/off"
+    "formidable/rules/eslint/best-practices/off",
+    "formidable/rules/eslint/errors/off",
+    "formidable/rules/eslint/es6/off",
+    "formidable/rules/eslint/node/off",
+    "formidable/rules/eslint/strict/off",
+    "formidable/rules/eslint/style/off",
+    "formidable/rules/eslint/variables/off"
   ],
   "parserOptions": {
     "ecmaVersion": 5,

--- a/package.json
+++ b/package.json
@@ -1,39 +1,29 @@
 {
-  "name"            : "eslint-config-formidable",
-  "description"     : "A set of default eslint configurations",
-
-  "version"         : "1.0.0",
-  "author"          : "Eric Baer <me@ericbaer.com>",
-
-  "homepage"        : "https://github.com/FormidableLabs/eslint-config-formidable",
+  "name": "eslint-config-walmart",
+  "description": "A set of default eslint configurations, Walmart Labs style.",
+  "version": "1.0.0",
+  "authors": "eric.baer@formidable.com, ryan.roemer@formidable.com, kyle.cesmat@formidable.com",
+  "homepage": "https://github.com/walmartlabs/eslint-config-walmart",
   "bugs": {
-    "url": "https://github.com/FormidableLabs/eslint-config-formidable/issues"
+    "url": "https://github.com/walmartlabs/eslint-config-walmart/issues"
   },
-
-  "repository"      : "git://github.com/FormidableLabs/eslint-config-formidable.git",
-  "private"         : false,
-
-  "dependencies": {
-  },
-
+  "repository": "git://github.com/walmartlabs/eslint-config-walmart.git",
+  "private": false,
+  "dependencies": {},
   "devDependencies" : {
     "babel-eslint": "6.0.4",
     "eslint": "^2.0.0",
     "eslint-plugin-filenames": "1.0.0",
     "eslint-plugin-react": "5.1.1"
   },
-
   "main": "configurations/es6.js",
   "scripts": {
     "test": "eslint configurations rules"
   },
-
   "engines":{
     "node": ">= 0.10.0"
   },
-
   "license": "MIT",
-
   "keywords": [
     "code checker",
     "code linter",
@@ -44,6 +34,6 @@
     "eslintconfig",
     "lint",
     "style checker",
-    "style linter"
+    "style linter",
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name"            : "eslint-config-walmart",
-  "description"     : "A set of default eslint configurations, Walmart Labs style.",
+  "name"            : "eslint-config-formidable",
+  "description"     : "A set of default eslint configurations",
 
   "version"         : "1.0.0",
   "author"          : "Eric Baer <me@ericbaer.com>",
 
-  "homepage"        : "https://github.com/walmartlabs/eslint-config-walmart",
+  "homepage"        : "https://github.com/FormidableLabs/eslint-config-formidable",
   "bugs": {
-    "url": "https://github.com/walmartlabs/eslint-config-walmart/issues"
+    "url": "https://github.com/FormidableLabs/eslint-config-formidable/issues"
   },
 
-  "repository"      : "git://github.com/walmartlabs/eslint-config-walmart.git",
+  "repository"      : "git://github.com/FormidableLabs/eslint-config-formidable.git",
   "private"         : false,
 
   "dependencies": {


### PR DESCRIPTION
Replacing references to walmart with formidable following the fork.
- Add Formidable to License #3 
- Update README to no longer reference walmart #2 
- Update file-paths to use formidable base #2 
- Update links in package.json to use correct repos

cc @ryan-roemer @exogen 
