### PR TITLE
Add eslint-plugin-import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@ extends:
   - "./rules/eslint/style/on.js"
   - "./rules/eslint/variables/on.js"
   - "./rules/filenames/on.js"
+  - "./rules/import/on.js"
   - "./rules/eslint/node/on.js"
 
 parserOptions:

--- a/README.md
+++ b/README.md
@@ -31,12 +31,6 @@ This package includes the following complete and ready to use configurations:
 - `formidable/configurations/es6-test` - ES6 + test
 - `formidable/configurations/es6` - ES6 config
 
-###### Dependencies
-
-- Any config (`formidable/configurations/<suffix>`) - [eslint-plugin-filenames](https://github.com/selaux/eslint-plugin-filenames)
-- Any React config (`<prefix>-react`) - [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react), [babel-eslint](https://github.com/babel/babel-eslint)
-- Any ES-next config (`es6-<suffix>`) - [babel-eslint](https://github.com/babel/babel-eslint)
-
 To consume and extend a config in ESLint just add the extends attribute to your `.eslintrc`. For
 more details about how shareable configs work, see the
 [ESLint documentation](http://eslint.org/docs/developer-guide/shareable-configs).

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ more details about how shareable configs work, see the
   - "formidable/configurations/es6-browser"
 ```
 
-**NOTE:** Extending multiple complete configs can cause unexpected results, if you need to do this you should consider a piecemeal config as explained below. See https://github.com/walmartlabs/eslint-config-defaults/issues/38 for details.
-
 ### Piecemeal Configurations
 
 ESLint configuration is broken apart in `./rules` containing ESLint's rules and rules for specific ESLint plugins. The full set of ESLint rules (`./rules/eslint`) are broken into categories that mirror ESLint's documentation. Under each rule type there are sets of configuration as well as an `off.js` file which turns off every rule in the category.
@@ -78,9 +76,10 @@ Due to an issue with ESLint, config extension cannot be called from a globally i
 
 ### This package tracks config in the following versions:
 
-- [ESLint](https://github.com/eslint/eslint) 2.10.2
-- [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react) 5.1.1
-- [eslint-plugin-filenames](https://www.npmjs.com/package/eslint-plugin-filenames) 1.0.0
+- [ESLint](https://github.com/eslint/eslint) 2.13.0
+- [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react) 6.0.0
+- [eslint-plugin-filenames](https://www.npmjs.com/package/eslint-plugin-filenames) 1.1.0
+- [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import) 1.12.0
 
 ## And A Special Thanks To
 

--- a/configurations/es5.js
+++ b/configurations/es5.js
@@ -9,7 +9,8 @@ module.exports = {
     "formidable/rules/eslint/strict/on",
     "formidable/rules/eslint/style/on",
     "formidable/rules/eslint/variables/on",
-    "formidable/rules/filenames/on"
+    "formidable/rules/filenames/on",
+    "formidable/rules/import/on"
   ],
   "parserOptions": {
     "ecmaVersion": 5,

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
   },
   "repository": "git://github.com/FormidableLabs/eslint-config-formidable.git",
   "private": false,
-  "dependencies": {},
-  "devDependencies" : {
-    "babel-eslint": "6.0.4",
-    "eslint": "^2.0.0",
-    "eslint-plugin-filenames": "1.0.0",
-    "eslint-plugin-react": "5.1.1"
+  "dependencies": {
+    "babel-eslint": "^6.1.0",
+    "eslint": "^2.13.0",
+    "eslint-plugin-filenames": "1.1.0",
+    "eslint-plugin-import": "^1.12.0",
+    "eslint-plugin-react": "^6.0.0"
   },
+  "devDependencies" : {},
   "main": "configurations/es6.js",
   "scripts": {
     "test": "eslint configurations rules"

--- a/rules/import/off.js
+++ b/rules/import/off.js
@@ -1,0 +1,23 @@
+"use strict";
+
+module.exports = {
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    // Ensure imports point to a file/module that can be resolved
+    "import/no-unresolved": 0,
+    // Ensure a default export is present, given a default import
+    "import/default": 0,
+    // Report any invalid exports, i.e. re-export of the same name
+    "import/export": 0,
+    // Forbid the use of extraneous packages
+    "import/no-extraneous-dependencies": 0,
+    // Forbid the use of mutable exports with var or let
+    "import/no-mutable-exports": 0,
+    // Ensure all imports appear before other statements
+    "import/imports-first": 0,
+    // Report repeated import of the same module in multiple places
+    "import/no-duplicates": 0
+  }
+};

--- a/rules/import/on.js
+++ b/rules/import/on.js
@@ -1,0 +1,23 @@
+"use strict";
+
+module.exports = {
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    // Ensure imports point to a file/module that can be resolved
+    "import/no-unresolved": 2,
+    // Ensure a default export is present, given a default import
+    "import/default": 0,
+    // Report any invalid exports, i.e. re-export of the same name
+    "import/export": 2,
+    // Forbid the use of extraneous packages
+    "import/no-extraneous-dependencies": 0,
+    // Forbid the use of mutable exports with var or let
+    "import/no-mutable-exports": 2,
+    // Ensure all imports appear before other statements
+    "import/imports-first": 2,
+    // Report repeated import of the same module in multiple places
+    "import/no-duplicates": 2
+  }
+};

--- a/rules/react/off.js
+++ b/rules/react/off.js
@@ -37,8 +37,6 @@ module.exports = {
     "react/prop-types": 0,
     // Prevent missing React when using JSX
     "react/react-in-jsx-scope": 0,
-    // Restrict file extensions that may be required
-    "react/require-extension": 0,
     // Enforce ES5 or ES6 class for returning value in render function
     "require-render-return": 0,
     // Prevent extra closing tags for components without children
@@ -47,8 +45,6 @@ module.exports = {
     "react/sort-comp": 0,
     // Enforce propTypes declarations alphabetical sorting
     "sort-prop-types": 0,
-    // Prevent missing parentheses around multilines JSX
-    "react/wrap-multilines": 0,
 
     // ========================================================================
     //                                JSX Specific Rules
@@ -93,6 +89,8 @@ module.exports = {
     // Prevent React to be incorrectly marked as unused
     "react/jsx-uses-react": 0,
     // Prevent variables used in JSX to be incorrectly marked as unused
-    "react/jsx-uses-vars": 0
+    "react/jsx-uses-vars": 0,
+    // Prevent missing parentheses around multilines JSX
+    "react/jsx-wrap-multilines": 0
   }
 };

--- a/rules/react/on.js
+++ b/rules/react/on.js
@@ -37,8 +37,6 @@ module.exports = {
     "react/prop-types": 2,
     // Prevent missing React when using JSX
     "react/react-in-jsx-scope": 2,
-    // Restrict file extensions that may be required
-    "react/require-extension": 0,
     // Enforce ES5 or ES6 class for returning value in render function
     "require-render-return": 0,
     // Prevent extra closing tags for components without children
@@ -47,8 +45,6 @@ module.exports = {
     "react/sort-comp": 0,
     // Enforce propTypes declarations alphabetical sorting
     "sort-prop-types": 0,
-    // Prevent missing parentheses around multilines JSX
-    "react/wrap-multilines": 2,
 
     // ========================================================================
     //                                JSX Specific Rules
@@ -93,6 +89,8 @@ module.exports = {
     // Prevent React to be incorrectly marked as unused
     "react/jsx-uses-react": 2,
     // Prevent variables used in JSX to be incorrectly marked as unused
-    "react/jsx-uses-vars": 2
+    "react/jsx-uses-vars": 2,
+    // Prevent missing parentheses around multilines JSX
+    "react/jsx-wrap-multilines": 2
   }
 };


### PR DESCRIPTION
- Added sensible rules for eslint-plugin-import
- Updated `eslint-plugin-react` to latest
- v6 of `eslint-plugin-react` deprecates  `react/require-extension` in favor of  `eslint-plugin-import` `extensions` rule. Also, rename `react/jsx-wrap-multilines`
- Moved packages to dependencies. I believe this is the right move so that downstream projects will not have to include the package & possible mismatch
- Update readme with latest versions & packages
- Remove "Extending multiple configs" note from README, that issue was fixed

closes #6 
closes FormidableLabs/formidable-landers#110

cc @ryan-roemer @kenwheeler @baer @exogen 
