### PR TITLE
Relax magic numbers, error object-curly, error react stylings

### DIFF
--- a/rules/eslint/best-practices/on.js
+++ b/rules/eslint/best-practices/on.js
@@ -63,13 +63,13 @@ module.exports = {
     // disallow usage of __iterator__ property
     "no-iterator": 2,
     // disallow use of labeled statements
-    "no-labels": [2, {"allowLoop": true, "allowSwitch": true}],
+    "no-labels": [2, { "allowLoop": true, "allowSwitch": true }],
     // disallow unnecessary nested blocks
     "no-lone-blocks": 2,
     // disallow creation of functions within loops
     "no-loop-func": 2,
     // disallow the use of magic numbers
-    "no-magic-numbers": 2,
+    "no-magic-numbers": ["error", { "ignore": [-1, 0, 1] }],
     // disallow use of multiple spaces
     "no-multi-spaces": 2,
     // disallow use of multiline strings

--- a/rules/eslint/style/on.js
+++ b/rules/eslint/style/on.js
@@ -37,7 +37,7 @@ module.exports = {
     // enforces spacing between keys and values in object literal properties
     "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
     // enforce spacing before and after keywords
-    "keyword-spacing": [2, {"before": true, "after": true}],
+    "keyword-spacing": [2, { "before": true, "after": true }],
     // disallow mixed "LF" and "CRLF" as linebreaks
     "linebreak-style": [0, "unix"],
     // enforces empty lines around comments
@@ -45,7 +45,7 @@ module.exports = {
     // specify the maximum depth that blocks can be nested
     "max-depth": [2, 4],
     // specify the maximum length of a line in your program
-    "max-len": [2, 100, 2, {"ignoreUrls": true, "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\("}],
+    "max-len": [2, 100, 2, { "ignoreUrls": true, "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(" }],
     // specify the maximum depth callbacks can be nested
     "max-nested-callbacks": [2, 3],
     // limits the number of parameters that can be used in the function declaration.
@@ -77,7 +77,7 @@ module.exports = {
     // disallow mixed spaces and tabs for indentation
     "no-mixed-spaces-and-tabs": 2,
     // disallow multiple empty lines
-    "no-multiple-empty-lines": [2, {"max": 2}],
+    "no-multiple-empty-lines": [2, { "max": 2 }],
     // disallow negated conditions
     "no-negated-condition": 0,
     // disallow nested ternary expressions
@@ -101,7 +101,7 @@ module.exports = {
     // disallow whitespace before properties
     "no-whitespace-before-property": 0,
     // require or disallow padding inside curly braces
-    "object-curly-spacing": [0, "never"],
+    "object-curly-spacing": ["error", "always"],
     // enforce placing object properties on separate lines
     "object-property-newline": 0,
     // allow just one var statement per function
@@ -123,7 +123,7 @@ module.exports = {
     // require or disallow use of semicolons instead of ASI
     "semi": 2,
     // enforce spacing before and after semicolons
-    "semi-spacing": [2, {"before": false, "after": true}],
+    "semi-spacing": [2, { "before": false, "after": true }],
     // enforce sorting import declarations within module
     "sort-imports": 0,
     // sort variables within the same declaration block
@@ -131,7 +131,7 @@ module.exports = {
     // require or disallow space before blocks
     "space-before-blocks": [2, "always"],
     // require or disallow space before function opening parenthesis
-    "space-before-function-paren": [2, {"anonymous": "always", "named": "never" }],
+    "space-before-function-paren": [2, { "anonymous": "always", "named": "never" }],
     // require or disallow spaces inside parentheses
     "space-in-parens": [2, "never"],
     // require spaces around operators

--- a/rules/eslint/variables/on.js
+++ b/rules/eslint/variables/on.js
@@ -23,7 +23,7 @@ module.exports = {
     // disallow use of undefined variable
     "no-undefined": 0,
     // disallow declaration of variables that are not used in the code
-    "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
+    "no-unused-vars": [2, { "vars": "all", "args": "after-used" }],
     // disallow use of variables before they are defined
     "no-use-before-define": 2
   }

--- a/rules/react/on.js
+++ b/rules/react/on.js
@@ -22,11 +22,11 @@ module.exports = {
     // Prevent usage of isMounted
     "react/no-is-mounted": 2,
     // Prevent multiple component definition per file
-    "react/no-multi-comp": 0,
+    "react/no-multi-comp": 2,
     // Prevent usage of setState
     "react/no-set-state": 0,
     // Prevent using string references in ref attribute.
-    "react/no-string-refs": 0,
+    "react/no-string-refs": 2,
     // Prevent usage of unknown DOM property
     "react/no-unknown-property": 2,
     // Enforce ES5 or ES6 class for React Components
@@ -42,9 +42,9 @@ module.exports = {
     // Prevent extra closing tags for components without children
     "react/self-closing-comp": 2,
     // Enforce component methods order
-    "react/sort-comp": 0,
+    "react/sort-comp": 2,
     // Enforce propTypes declarations alphabetical sorting
-    "sort-prop-types": 0,
+    "sort-prop-types": 2,
 
     // ========================================================================
     //                                JSX Specific Rules


### PR DESCRIPTION
This changes:
- Make magic numbers less magic `"no-magic-numbers": ["error", { "ignore": [-1, 0, 1] }]`
- Always enforce `"object-curly-spacing"`
- React changes below

```
"react/no-multi-comp": 2
"react/no-string-refs": 2,
"react/sort-comp": 2,
"sort-prop-types": 2,
```

closes #8 

cc @kenwheeler @ryan-roemer @exogen @baer 
