### PR TITLE
Correct bad path in es6-node config

### DIFF
--- a/configurations/es6-node.js
+++ b/configurations/es6-node.js
@@ -3,7 +3,7 @@
 module.exports = {
   "extends": [
     "formidable/configurations/es6",
-    "formidable/configurations/rules/eslint/node/on"
+    "formidable/rules/eslint/node/on"
   ],
   "env": {
     "node": true


### PR DESCRIPTION
This PR corrects a bad path in the es6-node config. Without this, the `es6-node` config fails with an error. This should be a patch release.

@kenwheeler @kylecesmat @ryan-roemer 
