### PR TITLE
Use Strings for Rule Values

### DIFF
--- a/configurations/es5-node.js
+++ b/configurations/es5-node.js
@@ -9,6 +9,6 @@ module.exports = {
     "node": true
   },
   "rules": {
-    "strict": [2, "global"]
+    "strict": ["error", "global"]
   }
 };

--- a/configurations/es5-test.js
+++ b/configurations/es5-test.js
@@ -8,6 +8,6 @@ module.exports = {
     "mocha": true
   },
   "rules": {
-    "max-nested-callbacks": 0
+    "max-nested-callbacks": "off"
   }
 };

--- a/configurations/es6-node-test.js
+++ b/configurations/es6-node-test.js
@@ -13,7 +13,7 @@ module.exports = {
     "sandbox": true
   },
   "rules": {
-    "max-nested-callbacks": 0,
-    "no-unused-expressions": 0
+    "max-nested-callbacks": "off",
+    "no-unused-expressions": "off"
   }
 };

--- a/configurations/es6-node.js
+++ b/configurations/es6-node.js
@@ -17,16 +17,16 @@ module.exports = {
   "globals": {},
   "rules": {
     // verify super() callings in constructors
-    "constructor-super": 0,
+    "constructor-super": "off",
     // disallow modifying variables of class declarations
-    "no-class-assign": 0,
+    "no-class-assign": "off",
     // disallow modifying variables that are declared using const
-    "no-dupe-class-members": 0,
+    "no-dupe-class-members": "off",
     // disallow to use this/super before super() calling in constructors.
-    "no-this-before-super": 0,
+    "no-this-before-super": "off",
     // suggest using Reflect methods where applicable
-    "prefer-reflect": 0,
+    "prefer-reflect": "off",
     // require that all functions are run in strict mode
-    "strict": [2, "global"]
+    "strict": ["error", "global"]
   }
 };

--- a/configurations/es6-react-test.js
+++ b/configurations/es6-react-test.js
@@ -7,6 +7,6 @@ module.exports = {
     "phantomjs": true
   },
   "rules": {
-    "max-nested-callbacks": 0
+    "max-nested-callbacks": "off"
   }
 };

--- a/configurations/es6-react.js
+++ b/configurations/es6-react.js
@@ -15,7 +15,7 @@ module.exports = {
     "fetch": false
   },
   "rules": {
-    "no-extra-parens": 0,
-    "no-var": 2
+    "no-extra-parens": "off",
+    "no-var": "error"
   }
 };

--- a/configurations/es6-test.js
+++ b/configurations/es6-test.js
@@ -7,6 +7,6 @@ module.exports = {
     "phantomjs": true
   },
   "rules": {
-    "max-nested-callbacks": 0
+    "max-nested-callbacks": "off"
   }
 };

--- a/rules/eslint/best-practices/off.js
+++ b/rules/eslint/best-practices/off.js
@@ -3,133 +3,133 @@
 module.exports = {
   "rules": {
     // Enforces getter/setter pairs in objects
-    "accessor-pairs": 0,
+    "accessor-pairs": "off",
     // enforce return statements in callbacks of array’s methods
-    "array-callback-return": 0,
+    "array-callback-return": "off",
     // treat var statements as if they were block scoped
-    "block-scoped-var": 0,
+    "block-scoped-var": "off",
     // specify the maximum cyclomatic complexity allowed in a program
-    "complexity": 0,
+    "complexity": "off",
     // require return statements to either always or never specify values
-    "consistent-return": 0,
+    "consistent-return": "off",
     // specify curly brace conventions for all control statements
-    "curly": 0,
+    "curly": "off",
     // require default case in switch statements
-    "default-case": 0,
+    "default-case": "off",
     // enforces consistent newlines before or after dots
-    "dot-location": 0,
+    "dot-location": "off",
     // encourages use of dot notation whenever possible
-    "dot-notation": 0,
+    "dot-notation": "off",
     // require the use of === and !==
-    "eqeqeq": 0,
+    "eqeqeq": "off",
     // make sure for-in loops have an if statement
-    "guard-for-in": 0,
+    "guard-for-in": "off",
     // disallow the use of alert, confirm, and prompt
-    "no-alert": 0,
+    "no-alert": "off",
     // disallow use of arguments.caller or arguments.callee
-    "no-caller": 0,
+    "no-caller": "off",
     // disallow lexical declarations in case clauses
-    "no-case-declarations": 0,
+    "no-case-declarations": "off",
     // disallow division operators explicitly at beginning of regular expression
-    "no-div-regex": 0,
+    "no-div-regex": "off",
     // disallow else after a return in an if
-    "no-else-return": 0,
+    "no-else-return": "off",
     // disallow use of empty functions
-    "no-empty-function": 0,
+    "no-empty-function": "off",
     // disallow use of empty destructuring patterns
-    "no-empty-pattern": 0,
+    "no-empty-pattern": "off",
     // disallow comparisons to null without a type-checking operator
-    "no-eq-null": 0,
+    "no-eq-null": "off",
     // disallow use of eval()
-    "no-eval": 0,
+    "no-eval": "off",
     // disallow adding to native types
-    "no-extend-native": 0,
+    "no-extend-native": "off",
     // disallow unnecessary function binding
-    "no-extra-bind": 0,
+    "no-extra-bind": "off",
     // disallow unnecessary labels
-    "no-extra-label": 0,
+    "no-extra-label": "off",
     // disallow fallthrough of case statements
-    "no-fallthrough": 0,
+    "no-fallthrough": "off",
     // disallow the use of leading or trailing decimal points in numeric literals
-    "no-floating-decimal": 0,
+    "no-floating-decimal": "off",
     // disallow the type conversions with shorter notations
-    "no-implicit-coercion": 0,
+    "no-implicit-coercion": "off",
     // disallow var and named functions in global scope
-    "no-implicit-globals": 0,
+    "no-implicit-globals": "off",
     // disallow use of eval()-like methods
-    "no-implied-eval": 0,
+    "no-implied-eval": "off",
     // disallow this keywords outside of classes or class-like objects
-    "no-invalid-this": 0,
+    "no-invalid-this": "off",
     // disallow usage of __iterator__ property
-    "no-iterator": 0,
+    "no-iterator": "off",
     // disallow use of labeled statements
-    "no-labels": 0,
+    "no-labels": "off",
     // disallow unnecessary nested blocks
-    "no-lone-blocks": 0,
+    "no-lone-blocks": "off",
     // disallow creation of functions within loops
-    "no-loop-func": 0,
+    "no-loop-func": "off",
     // disallow the use of magic numbers
-    "no-magic-numbers": 0,
+    "no-magic-numbers": "off",
     // disallow use of multiple spaces
-    "no-multi-spaces": 0,
+    "no-multi-spaces": "off",
     // disallow use of multiline strings
-    "no-multi-str": 0,
+    "no-multi-str": "off",
     // disallow reassignments of native objects
-    "no-native-reassign": 0,
+    "no-native-reassign": "off",
     // disallow use of new operator when not part of the assignment or comparison
-    "no-new": 0,
+    "no-new": "off",
     // disallow use of new operator for Function object
-    "no-new-func": 0,
+    "no-new-func": "off",
     // disallows creating new instances of String,Number, and Boolean
-    "no-new-wrappers": 0,
+    "no-new-wrappers": "off",
     // disallow use of (old style) octal literals
-    "no-octal": 0,
+    "no-octal": "off",
     // disallow use of octal escape sequences in string literals, such as
     // var foo = "Copyright \251";
-    "no-octal-escape": 0,
+    "no-octal-escape": "off",
     // disallow reassignment of function parameters
-    "no-param-reassign": 0,
+    "no-param-reassign": "off",
     // disallow usage of __proto__ property
-    "no-proto": 0,
+    "no-proto": "off",
     // disallow declaring the same variable more then once
-    "no-redeclare": 0,
+    "no-redeclare": "off",
     // disallow use of assignment in return statement
-    "no-return-assign": 0,
+    "no-return-assign": "off",
     // disallow use of `javascript:` urls.
-    "no-script-url": 0,
+    "no-script-url": "off",
     // disallow assignments where both sides are exactly the same
-    "no-self-assign": 0,
+    "no-self-assign": "off",
     // disallow comparisons where both sides are exactly the same
-    "no-self-compare": 0,
+    "no-self-compare": "off",
     // disallow use of comma operator
-    "no-sequences": 0,
+    "no-sequences": "off",
     // restrict what can be thrown as an exception
-    "no-throw-literal": 0,
+    "no-throw-literal": "off",
     // disallow unmodified conditions of loops
-    "no-unmodified-loop-condition": 0,
+    "no-unmodified-loop-condition": "off",
     // disallow usage of expressions in statement position
-    "no-unused-expressions": 0,
+    "no-unused-expressions": "off",
     // disallow unused labels
-    "no-unused-labels": 0,
+    "no-unused-labels": "off",
     // disallow unnecessary .call() and .apply()
-    "no-useless-call": 0,
+    "no-useless-call": "off",
     // disallow unnecessary concatenation of literals or template literals
-    "no-useless-concat": 0,
+    "no-useless-concat": "off",
     // disallow unnecessary usage of escape character
-    "no-useless-escape": 0,
+    "no-useless-escape": "off",
     // disallow use of void operator
-    "no-void": 0,
+    "no-void": "off",
     // disallow usage of configurable warning terms in comments: e.g. todo
-    "no-warning-comments": 0,
+    "no-warning-comments": "off",
     // disallow use of the with statement
-    "no-with": 0,
+    "no-with": "off",
     // require use of the second argument for parseInt()
-    "radix": 0,
+    "radix": "off",
     // requires to declare all vars on top of their containing scope
-    "vars-on-top": 0,
+    "vars-on-top": "off",
     // require immediate function invocation to be wrapped in parentheses
-    "wrap-iife": 0,
+    "wrap-iife": "off",
     // require or disallow Yoda conditions
-    "yoda": 0
+    "yoda": "off"
   }
 };

--- a/rules/eslint/best-practices/on.js
+++ b/rules/eslint/best-practices/on.js
@@ -3,133 +3,133 @@
 module.exports = {
   "rules": {
     // Enforces getter/setter pairs in objects
-    "accessor-pairs": 0,
+    "accessor-pairs": "off",
     // enforce return statements in callbacks of array’s methods
-    "array-callback-return": 0,
+    "array-callback-return": "off",
     // treat var statements as if they were block scoped
-    "block-scoped-var": 0,
+    "block-scoped-var": "off",
     // specify the maximum cyclomatic complexity allowed in a program
-    "complexity": [2, 11],
+    "complexity": ["error", 11],
     // require return statements to either always or never specify values
-    "consistent-return": 2,
+    "consistent-return": "error",
     // specify curly brace conventions for all control statements
-    "curly": [2, "all"],
+    "curly": ["error", "all"],
     // require default case in switch statements
-    "default-case": 0,
+    "default-case": "off",
     // enforces consistent newlines before or after dots
-    "dot-location": 0,
+    "dot-location": "off",
     // encourages use of dot notation whenever possible
-    "dot-notation": [2, { "allowKeywords": true }],
+    "dot-notation": ["error", { "allowKeywords": true }],
     // require the use of === and !==
-    "eqeqeq": 2,
+    "eqeqeq": "error",
     // make sure for-in loops have an if statement
-    "guard-for-in": 0,
+    "guard-for-in": "off",
     // disallow the use of alert, confirm, and prompt
-    "no-alert": 2,
+    "no-alert": "error",
     // disallow use of arguments.caller or arguments.callee
-    "no-caller": 2,
+    "no-caller": "error",
     // disallow lexical declarations in case clauses
-    "no-case-declarations": 2,
+    "no-case-declarations": "error",
     // disallow division operators explicitly at beginning of regular expression
-    "no-div-regex": 0,
+    "no-div-regex": "off",
     // disallow else after a return in an if
-    "no-else-return": 0,
+    "no-else-return": "off",
     // disallow use of empty functions
-    "no-empty-function": 0,
+    "no-empty-function": "off",
     // disallow use of empty destructuring patterns
-    "no-empty-pattern": 2,
+    "no-empty-pattern": "error",
     // disallow comparisons to null without a type-checking operator
-    "no-eq-null": 0,
+    "no-eq-null": "off",
     // disallow use of eval()
-    "no-eval": 2,
+    "no-eval": "error",
     // disallow adding to native types
-    "no-extend-native": 2,
+    "no-extend-native": "error",
     // disallow unnecessary function binding
-    "no-extra-bind": 2,
+    "no-extra-bind": "error",
     // disallow unnecessary labels
-    "no-extra-label": 0,
+    "no-extra-label": "off",
     // disallow fallthrough of case statements
-    "no-fallthrough": 2,
+    "no-fallthrough": "error",
     // disallow the use of leading or trailing decimal points in numeric literals
-    "no-floating-decimal": 0,
+    "no-floating-decimal": "off",
     // disallow the type conversions with shorter notations
-    "no-implicit-coercion": 0,
+    "no-implicit-coercion": "off",
     // disallow var and named functions in global scope
-    "no-implicit-globals": 0,
+    "no-implicit-globals": "off",
     // disallow use of eval()-like methods
-    "no-implied-eval": 2,
+    "no-implied-eval": "error",
     // disallow this keywords outside of classes or class-like objects
-    "no-invalid-this": 2,
+    "no-invalid-this": "error",
     // disallow usage of __iterator__ property
-    "no-iterator": 2,
+    "no-iterator": "error",
     // disallow use of labeled statements
-    "no-labels": [2, { "allowLoop": true, "allowSwitch": true }],
+    "no-labels": ["error", { "allowLoop": true, "allowSwitch": true }],
     // disallow unnecessary nested blocks
-    "no-lone-blocks": 2,
+    "no-lone-blocks": "error",
     // disallow creation of functions within loops
-    "no-loop-func": 2,
+    "no-loop-func": "error",
     // disallow the use of magic numbers
     "no-magic-numbers": ["error", { "ignore": [-1, 0, 1] }],
     // disallow use of multiple spaces
-    "no-multi-spaces": 2,
+    "no-multi-spaces": "error",
     // disallow use of multiline strings
-    "no-multi-str": 2,
+    "no-multi-str": "error",
     // disallow reassignments of native objects
-    "no-native-reassign": 2,
+    "no-native-reassign": "error",
     // disallow use of new operator when not part of the assignment or comparison
-    "no-new": 2,
+    "no-new": "error",
     // disallow use of new operator for Function object
-    "no-new-func": 2,
+    "no-new-func": "error",
     // disallows creating new instances of String,Number, and Boolean
-    "no-new-wrappers": 2,
+    "no-new-wrappers": "error",
     // disallow use of (old style) octal literals
-    "no-octal": 2,
+    "no-octal": "error",
     // disallow use of octal escape sequences in string literals, such as
     // var foo = "Copyright \251";
-    "no-octal-escape": 2,
+    "no-octal-escape": "error",
     // disallow reassignment of function parameters
-    "no-param-reassign": 0,
+    "no-param-reassign": "off",
     // disallow usage of __proto__ property
-    "no-proto": 2,
+    "no-proto": "error",
     // disallow declaring the same variable more then once
-    "no-redeclare": 2,
+    "no-redeclare": "error",
     // disallow use of assignment in return statement
-    "no-return-assign": 2,
+    "no-return-assign": "error",
     // disallow use of `javascript:` urls.
-    "no-script-url": 2,
+    "no-script-url": "error",
     // disallow assignments where both sides are exactly the same
-    "no-self-assign": 0,
+    "no-self-assign": "off",
     // disallow comparisons where both sides are exactly the same
-    "no-self-compare": 2,
+    "no-self-compare": "error",
     // disallow use of comma operator
-    "no-sequences": 2,
+    "no-sequences": "error",
     // restrict what can be thrown as an exception
-    "no-throw-literal": 2,
+    "no-throw-literal": "error",
     // disallow unmodified conditions of loops
-    "no-unmodified-loop-condition": 0,
+    "no-unmodified-loop-condition": "off",
     // disallow usage of expressions in statement position
-    "no-unused-expressions": 2,
+    "no-unused-expressions": "error",
     // disallow unused labels
-    "no-unused-labels": 0,
+    "no-unused-labels": "off",
     // disallow unnecessary .call() and .apply()
-    "no-useless-call": 2,
+    "no-useless-call": "error",
     // disallow unnecessary concatenation of literals or template literals
-    "no-useless-concat": 2,
+    "no-useless-concat": "error",
     // disallow unnecessary usage of escape character
-    "no-useless-escape": 0,
+    "no-useless-escape": "off",
     // disallow use of void operator
-    "no-void": 0,
+    "no-void": "off",
     // disallow usage of configurable warning terms in comments: e.g. todo
-    "no-warning-comments": 0,
+    "no-warning-comments": "off",
     // disallow use of the with statement
-    "no-with": 2,
+    "no-with": "error",
     // require use of the second argument for parseInt()
-    "radix": 0,
+    "radix": "off",
     // requires to declare all vars on top of their containing scope
-    "vars-on-top": 0,
+    "vars-on-top": "off",
     // require immediate function invocation to be wrapped in parentheses
-    "wrap-iife": 0,
+    "wrap-iife": "off",
     // require or disallow Yoda conditions
-    "yoda": [2, "never"]
+    "yoda": ["error", "never"]
   }
 };

--- a/rules/eslint/errors/off.js
+++ b/rules/eslint/errors/off.js
@@ -3,62 +3,62 @@
 module.exports = {
   "rules": {
     // disallow trailing commas in object literals
-    "comma-dangle": 0,
+    "comma-dangle": "off",
     // disallow assignment in conditional expressions
-    "no-cond-assign": 0,
+    "no-cond-assign": "off",
     // disallow use of console
-    "no-console": 0,
+    "no-console": "off",
     // disallow use of constant expressions in conditions
-    "no-constant-condition": 0,
+    "no-constant-condition": "off",
     // disallow control characters in regular expressions
-    "no-control-regex": 0,
+    "no-control-regex": "off",
     // disallow use of debugger
-    "no-debugger": 0,
+    "no-debugger": "off",
     // disallow duplicate arguments in functions
-    "no-dupe-args": 0,
+    "no-dupe-args": "off",
     // disallow duplicate keys when creating object literals
-    "no-dupe-keys": 0,
+    "no-dupe-keys": "off",
     // disallow a duplicate case label.
-    "no-duplicate-case": 0,
+    "no-duplicate-case": "off",
     // disallow empty statements
-    "no-empty": 0,
+    "no-empty": "off",
     // disallow the use of empty character classes in regular expressions
-    "no-empty-character-class": 0,
+    "no-empty-character-class": "off",
     // disallow assigning to the exception in a catch block
-    "no-ex-assign": 0,
+    "no-ex-assign": "off",
     // disallow double-negation boolean casts in a boolean context
-    "no-extra-boolean-cast": 0,
+    "no-extra-boolean-cast": "off",
     // disallow unnecessary parentheses
-    "no-extra-parens": 0,
+    "no-extra-parens": "off",
     // disallow unnecessary semicolons
-    "no-extra-semi": 0,
+    "no-extra-semi": "off",
     // disallow overwriting functions written as function declarations
-    "no-func-assign": 0,
+    "no-func-assign": "off",
     // disallow function or variable declarations in nested blocks
-    "no-inner-declarations": 0,
+    "no-inner-declarations": "off",
     // disallow invalid regular expression strings in the RegExp constructor
-    "no-invalid-regexp": 0,
+    "no-invalid-regexp": "off",
     // disallow irregular whitespace outside of strings and comments
-    "no-irregular-whitespace": 0,
+    "no-irregular-whitespace": "off",
     // disallow negation of the left operand of an in expression
-    "no-negated-in-lhs": 0,
+    "no-negated-in-lhs": "off",
     // disallow the use of object properties of the global object (Math and JSON) as functions
-    "no-obj-calls": 0,
+    "no-obj-calls": "off",
     // disallow multiple spaces in a regular expression literal
-    "no-regex-spaces": 0,
+    "no-regex-spaces": "off",
     // disallow sparse arrays
-    "no-sparse-arrays": 0,
+    "no-sparse-arrays": "off",
     // Avoid code that looks like two expressions but is actually one
-    "no-unexpected-multiline": 0,
+    "no-unexpected-multiline": "off",
     // disallow unreachable statements after a return, throw, continue, or break statement
-    "no-unreachable": 0,
+    "no-unreachable": "off",
     // disallow control flow statements in finally blocks
-    "no-unsafe-finally": 0,
+    "no-unsafe-finally": "off",
     // disallow comparisons with the value NaN
-    "use-isnan": 0,
+    "use-isnan": "off",
     // ensure JSDoc comments are valid
-    "valid-jsdoc": 0,
+    "valid-jsdoc": "off",
     // ensure that the results of typeof are compared against a valid string
-    "valid-typeof": 0
+    "valid-typeof": "off"
   }
 };

--- a/rules/eslint/errors/on.js
+++ b/rules/eslint/errors/on.js
@@ -3,62 +3,62 @@
 module.exports = {
   "rules": {
     // disallow trailing commas in object literals
-    "comma-dangle": [2, "never"],
+    "comma-dangle": ["error", "never"],
     // disallow assignment in conditional expressions
-    "no-cond-assign": 2,
+    "no-cond-assign": "error",
     // disallow use of console
-    "no-console": 2,
+    "no-console": "error",
     // disallow use of constant expressions in conditions
-    "no-constant-condition": 2,
+    "no-constant-condition": "error",
     // disallow control characters in regular expressions
-    "no-control-regex": 2,
+    "no-control-regex": "error",
     // disallow use of debugger
-    "no-debugger": 2,
+    "no-debugger": "error",
     // disallow duplicate arguments in functions
-    "no-dupe-args": 2,
+    "no-dupe-args": "error",
     // disallow duplicate keys when creating object literals
-    "no-dupe-keys": 2,
+    "no-dupe-keys": "error",
     // disallow a duplicate case label.
-    "no-duplicate-case": 2,
+    "no-duplicate-case": "error",
     // disallow empty statements
-    "no-empty": 2,
+    "no-empty": "error",
     // disallow the use of empty character classes in regular expressions
-    "no-empty-character-class": 2,
+    "no-empty-character-class": "error",
     // disallow assigning to the exception in a catch block
-    "no-ex-assign": 2,
+    "no-ex-assign": "error",
     // disallow double-negation boolean casts in a boolean context
-    "no-extra-boolean-cast": 2,
+    "no-extra-boolean-cast": "error",
     // disallow unnecessary parentheses
-    "no-extra-parens": 2,
+    "no-extra-parens": "error",
     // disallow unnecessary semicolons
-    "no-extra-semi": 2,
+    "no-extra-semi": "error",
     // disallow overwriting functions written as function declarations
-    "no-func-assign": 2,
+    "no-func-assign": "error",
     // disallow function or variable declarations in nested blocks
-    "no-inner-declarations": [2, "functions"],
+    "no-inner-declarations": ["error", "functions"],
     // disallow invalid regular expression strings in the RegExp constructor
-    "no-invalid-regexp": 2,
+    "no-invalid-regexp": "error",
     // disallow irregular whitespace outside of strings and comments
-    "no-irregular-whitespace": 2,
+    "no-irregular-whitespace": "error",
     // disallow negation of the left operand of an in expression
-    "no-negated-in-lhs": 2,
+    "no-negated-in-lhs": "error",
     // disallow the use of object properties of the global object (Math and JSON) as functions
-    "no-obj-calls": 2,
+    "no-obj-calls": "error",
     // disallow multiple spaces in a regular expression literal
-    "no-regex-spaces": 2,
+    "no-regex-spaces": "error",
     // disallow sparse arrays
-    "no-sparse-arrays": 2,
+    "no-sparse-arrays": "error",
     // Avoid code that looks like two expressions but is actually one
-    "no-unexpected-multiline": 2,
+    "no-unexpected-multiline": "error",
     // disallow unreachable statements after a return, throw, continue, or break statement
-    "no-unreachable": 2,
+    "no-unreachable": "error",
     // disallow control flow statements in finally blocks
-    "no-unsafe-finally": 0,
+    "no-unsafe-finally": "off",
     // disallow comparisons with the value NaN
-    "use-isnan": 2,
+    "use-isnan": "error",
     // ensure JSDoc comments are valid
-    "valid-jsdoc": 2,
+    "valid-jsdoc": "error",
     // ensure that the results of typeof are compared against a valid string
-    "valid-typeof": 2
+    "valid-typeof": "error"
   }
 };

--- a/rules/eslint/es6/off.js
+++ b/rules/eslint/es6/off.js
@@ -3,58 +3,58 @@
 module.exports = {
   "rules": {
     // require braces in arrow function body
-    "arrow-body-style": 0,
+    "arrow-body-style": "off",
     // require parens in arrow function arguments
-    "arrow-parens": 0,
+    "arrow-parens": "off",
     // require space before/after arrow function's arrow
-    "arrow-spacing": 0,
+    "arrow-spacing": "off",
     // verify super() callings in constructors
-    "constructor-super": 0,
+    "constructor-super": "off",
     // enforce the spacing around the * in generator functions
-    "generator-star-spacing": 0,
+    "generator-star-spacing": "off",
     // disallow modifying variables of class declarations
-    "no-class-assign": 0,
+    "no-class-assign": "off",
     // disallow arrow functions where they could be confused with comparisons
-    "no-confusing-arrow": 0,
+    "no-confusing-arrow": "off",
     // disallow modifying variables that are declared using const
-    "no-const-assign": 0,
+    "no-const-assign": "off",
     // disallow duplicate name in class members
-    "no-dupe-class-members": 0,
+    "no-dupe-class-members": "off",
     // disallow duplicate module imports
-    "no-duplicate-imports": 0,
+    "no-duplicate-imports": "off",
     // disallow use of the new operator with the Symbol object
-    "no-new-symbol": 0,
+    "no-new-symbol": "off",
     // restrict usage of specified modules when loaded by import declaration
-    "no-restricted-imports": 0,
+    "no-restricted-imports": "off",
     // disallow to use this/super before super() calling in constructors.
-    "no-this-before-super": 0,
+    "no-this-before-super": "off",
     // disallow unnecessary computed property keys in object literals
-    "no-useless-computed-key": 0,
+    "no-useless-computed-key": "off",
     // disallow unnecessary constructor
-    "no-useless-constructor": 0,
+    "no-useless-constructor": "off",
     // require let or const instead of var
-    "no-var": 0,
+    "no-var": "off",
     // require method and property shorthand syntax for object literals
-    "object-shorthand": 0,
+    "object-shorthand": "off",
     // suggest using arrow functions as callbacks
-    "prefer-arrow-callback": 0,
+    "prefer-arrow-callback": "off",
     // suggest using of const declaration for variables that are never modified after declared
-    "prefer-const": 0,
+    "prefer-const": "off",
     // suggest using Reflect methods where applicable
-    "prefer-reflect": 0,
+    "prefer-reflect": "off",
     // suggest using the rest parameters instead of arguments
-    "prefer-rest-params": 0,
+    "prefer-rest-params": "off",
     // suggest using the spread operator instead of .apply()
-    "prefer-spread": 0,
+    "prefer-spread": "off",
     // suggest using template literals instead of strings concatenation
-    "prefer-template": 0,
+    "prefer-template": "off",
     // disallow generator functions that do not have yield
-    "require-yield": 0,
+    "require-yield": "off",
     // enforce sorted import declarations within modules
-    "sort-imports": 0,
+    "sort-imports": "off",
     // enforce spacing around embedded expressions of template strings
-    "template-curly-spacing": 0,
+    "template-curly-spacing": "off",
     // enforce spacing around the * in yield* expressions
-    "yield-star-spacing": 0
+    "yield-star-spacing": "off"
   }
 };

--- a/rules/eslint/es6/on.js
+++ b/rules/eslint/es6/on.js
@@ -3,58 +3,58 @@
 module.exports = {
   "rules": {
     // require braces in arrow function body
-    "arrow-body-style": 0,
+    "arrow-body-style": "off",
     // require parens in arrow function arguments
-    "arrow-parens": 2,
+    "arrow-parens": "error",
     // require space before/after arrow function's arrow
-    "arrow-spacing": 2,
+    "arrow-spacing": "error",
     // verify super() callings in constructors
-    "constructor-super": 2,
+    "constructor-super": "error",
     // enforce the spacing around the * in generator functions
-    "generator-star-spacing": 2,
+    "generator-star-spacing": "error",
     // disallow modifying variables of class declarations
-    "no-class-assign": 2,
+    "no-class-assign": "error",
     // disallow arrow functions where they could be confused with comparisons
-    "no-confusing-arrow": 0,
+    "no-confusing-arrow": "off",
     // disallow modifying variables that are declared using const
-    "no-const-assign": 2,
+    "no-const-assign": "error",
     // disallow duplicate name in class members
-    "no-dupe-class-members": 2,
+    "no-dupe-class-members": "error",
     // disallow duplicate module imports
-    "no-duplicate-imports": 0,
+    "no-duplicate-imports": "off",
     // disallow use of the new operator with the Symbol object
-    "no-new-symbol": 0,
+    "no-new-symbol": "off",
     // restrict usage of specified modules when loaded by import declaration
-    "no-restricted-imports": 0,
+    "no-restricted-imports": "off",
     // disallow to use this/super before super() calling in constructors.
-    "no-this-before-super": 2,
+    "no-this-before-super": "error",
     // disallow unnecessary computed property keys in object literals
-    "no-useless-computed-key": 0,
+    "no-useless-computed-key": "off",
     // disallow unnecessary constructor
-    "no-useless-constructor": 0,
+    "no-useless-constructor": "off",
     // require let or const instead of var
-    "no-var": 2,
+    "no-var": "error",
     // require method and property shorthand syntax for object literals
-    "object-shorthand": 2,
+    "object-shorthand": "error",
     // suggest using arrow functions as callbacks
-    "prefer-arrow-callback": 1,
+    "prefer-arrow-callback": "warn",
     // suggest using of const declaration for variables that are never modified after declared
-    "prefer-const": 2,
+    "prefer-const": "error",
     // suggest using Reflect methods where applicable
-    "prefer-reflect": 0,
+    "prefer-reflect": "off",
     // suggest using the rest parameters instead of arguments
-    "prefer-rest-params": 0,
+    "prefer-rest-params": "off",
     // suggest using the spread operator instead of .apply()
-    "prefer-spread": 2,
+    "prefer-spread": "error",
     // suggest using template literals instead of strings concatenation
-    "prefer-template": 1,
+    "prefer-template": "warn",
     // disallow generator functions that do not have yield
-    "require-yield": 2,
+    "require-yield": "error",
     // enforce sorted import declarations within modules
-    "sort-imports": 0,
+    "sort-imports": "off",
     // enforce spacing around embedded expressions of template strings
-    "template-curly-spacing": 0,
+    "template-curly-spacing": "off",
     // enforce spacing around the * in yield* expressions
-    "yield-star-spacing": 0
+    "yield-star-spacing": "off"
   }
 };

--- a/rules/eslint/node/off.js
+++ b/rules/eslint/node/off.js
@@ -3,24 +3,24 @@
 module.exports = {
   "rules": {
     // enforce return after a callback
-    "callback-return": 0,
+    "callback-return": "off",
     // disallow require() outside of the top-level module scope
-    "global-require": 0,
+    "global-require": "off",
     // enforces error handling in callbacks (node environment)
-    "handle-callback-err": 0,
+    "handle-callback-err": "off",
     // disallow mixing regular variable and require declarations
-    "no-mixed-requires": 0,
+    "no-mixed-requires": "off",
     // disallow use of new operator with the require function
-    "no-new-require": 0,
+    "no-new-require": "off",
     // disallow string concatenation with __dirname and __filename
-    "no-path-concat": 0,
+    "no-path-concat": "off",
     // disallow use of process.env
-    "no-process-env": 0,
+    "no-process-env": "off",
     // disallow process.exit()
-    "no-process-exit": 0,
+    "no-process-exit": "off",
     // restrict usage of specified node modules
-    "no-restricted-modules": 0,
+    "no-restricted-modules": "off",
     // disallow use of synchronous methods (off by default)
-    "no-sync": 0
+    "no-sync": "off"
   }
 };

--- a/rules/eslint/node/on.js
+++ b/rules/eslint/node/on.js
@@ -3,24 +3,24 @@
 module.exports = {
   "rules": {
     // enforce return after a callback
-    "callback-return": 2,
+    "callback-return": "error",
     // disallow require() outside of the top-level module scope
-    "global-require": 1,
+    "global-require": "warn",
     // enforces error handling in callbacks (node environment)
-    "handle-callback-err": 0,
+    "handle-callback-err": "off",
     // disallow mixing regular variable and require declarations
-    "no-mixed-requires": 2,
+    "no-mixed-requires": "error",
     // disallow use of new operator with the require function
-    "no-new-require": 2,
+    "no-new-require": "error",
     // disallow string concatenation with __dirname and __filename
-    "no-path-concat": 0,
+    "no-path-concat": "off",
     // disallow use of process.env
-    "no-process-env": 0,
+    "no-process-env": "off",
     // disallow process.exit()
-    "no-process-exit": 2,
+    "no-process-exit": "error",
     // restrict usage of specified node modules
-    "no-restricted-modules": 0,
+    "no-restricted-modules": "off",
     // disallow use of synchronous methods (off by default)
-    "no-sync": 0
+    "no-sync": "off"
   }
 };

--- a/rules/eslint/strict/off.js
+++ b/rules/eslint/strict/off.js
@@ -3,6 +3,6 @@
 module.exports = {
   "rules": {
     // require that all functions are run in strict mode
-    "strict": 0
+    "strict": "off"
   }
 };

--- a/rules/eslint/strict/on.js
+++ b/rules/eslint/strict/on.js
@@ -3,6 +3,6 @@
 module.exports = {
   "rules": {
     // require that all functions are run in strict mode
-    "strict": [2, "never"]
+    "strict": ["error", "never"]
   }
 };

--- a/rules/eslint/style/off.js
+++ b/rules/eslint/style/off.js
@@ -3,144 +3,144 @@
 module.exports = {
   "rules": {
     // enforce spacing inside array brackets
-    "array-bracket-spacing": 0,
+    "array-bracket-spacing": "off",
     // disallow or enforce spaces inside of single line blocks
-    "block-spacing": 0,
+    "block-spacing": "off",
     // enforce one true brace style
-    "brace-style": 0,
+    "brace-style": "off",
     // require camel case names
-    "camelcase": 0,
+    "camelcase": "off",
     // enforce spacing before and after comma
-    "comma-spacing": 0,
+    "comma-spacing": "off",
     // enforce one true comma style
-    "comma-style": 0,
+    "comma-style": "off",
     // require or disallow padding inside computed properties
-    "computed-property-spacing": 0,
+    "computed-property-spacing": "off",
     // enforces consistent naming when capturing the current execution context
-    "consistent-this": 0,
+    "consistent-this": "off",
     // enforce newline at the end of file, with no multiple empty lines
-    "eol-last": 0,
+    "eol-last": "off",
     // require function expressions to have a name
-    "func-names": 0,
+    "func-names": "off",
     // enforces use of function declarations or expressions
-    "func-style": 0,
+    "func-style": "off",
     // disallow certain identifiers to prevent them being used
-    "id-blacklist": 0,
+    "id-blacklist": "off",
     // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-    "id-length": 0,
+    "id-length": "off",
     // require identifiers to match the provided regular expression
-    "id-match": 0,
+    "id-match": "off",
     // this option sets a specific tab width for your code
-    "indent": 0,
+    "indent": "off",
     // specify whether double or single quotes should be used in JSX attributes
-    "jsx-quotes": 0,
+    "jsx-quotes": "off",
     // enforces spacing between keys and values in object literal properties
-    "key-spacing": 0,
+    "key-spacing": "off",
     // enforce spacing before and after keywords
-    "keyword-spacing": 0,
+    "keyword-spacing": "off",
     // disallow mixed "LF" and "CRLF" as linebreaks
-    "linebreak-style": 0,
+    "linebreak-style": "off",
     // enforces empty lines around comments
-    "lines-around-comment": 0,
+    "lines-around-comment": "off",
     // specify the maximum depth that blocks can be nested
-    "max-depth": 0,
+    "max-depth": "off",
     // specify the maximum length of a line in your program
-    "max-len": 0,
+    "max-len": "off",
     // specify the maximum depth callbacks can be nested
-    "max-nested-callbacks": 0,
+    "max-nested-callbacks": "off",
     // limits the number of parameters that can be used in the function declaration.
-    "max-params": 0,
+    "max-params": "off",
     // specify the maximum number of statement allowed in a function
-    "max-statements": 0,
+    "max-statements": "off",
     // specify the maximum number of statements allowed per line
-    "max-statements-per-line": 0,
+    "max-statements-per-line": "off",
     // require a capital letter for constructors
-    "new-cap": 0,
+    "new-cap": "off",
     // disallow the omission of parentheses when invoking a constructor with no arguments
-    "new-parens": 0,
+    "new-parens": "off",
     // allow/disallow an empty newline after var statement
-    "newline-after-var": 0,
+    "newline-after-var": "off",
     // require newline before return statement
-    "newline-before-return": 0,
+    "newline-before-return": "off",
     // enforce newline after each call when chaining the calls
-    "newline-per-chained-call": 0,
+    "newline-per-chained-call": "off",
     // disallow use of the Array constructor
-    "no-array-constructor": 0,
+    "no-array-constructor": "off",
     // disallow use of bitwise operators
-    "no-bitwise": 0,
+    "no-bitwise": "off",
     // disallow use of the continue statement
-    "no-continue": 0,
+    "no-continue": "off",
     // disallow comments inline after code
-    "no-inline-comments": 0,
+    "no-inline-comments": "off",
     // disallow if as the only statement in an else block
-    "no-lonely-if": 0,
+    "no-lonely-if": "off",
     // disallow mixed spaces and tabs for indentation
-    "no-mixed-spaces-and-tabs": 0,
+    "no-mixed-spaces-and-tabs": "off",
     // disallow multiple empty lines
-    "no-multiple-empty-lines": 0,
+    "no-multiple-empty-lines": "off",
     // disallow negated conditions
-    "no-negated-condition": 0,
+    "no-negated-condition": "off",
     // disallow nested ternary expressions
-    "no-nested-ternary": 0,
+    "no-nested-ternary": "off",
     // disallow use of the Object constructor
-    "no-new-object": 0,
+    "no-new-object": "off",
     // disallow use of unary operators, ++ and --
-    "no-plusplus": 0,
+    "no-plusplus": "off",
     // disallow use of certain syntax in code
-    "no-restricted-syntax": 0,
+    "no-restricted-syntax": "off",
     // disallow space between function identifier and application
-    "no-spaced-func": 0,
+    "no-spaced-func": "off",
     // disallow the use of ternary operators
-    "no-ternary": 0,
+    "no-ternary": "off",
     // disallow trailing whitespace at the end of lines
-    "no-trailing-spaces": 0,
+    "no-trailing-spaces": "off",
     // disallow dangling underscores in identifiers
-    "no-underscore-dangle": 0,
+    "no-underscore-dangle": "off",
     // disallow the use of Boolean literals in conditional expressions
-    "no-unneeded-ternary": 0,
+    "no-unneeded-ternary": "off",
     // disallow whitespace before properties
-    "no-whitespace-before-property": 0,
+    "no-whitespace-before-property": "off",
     // require or disallow padding inside curly braces
-    "object-curly-spacing": 0,
+    "object-curly-spacing": "off",
     // enforce placing object properties on separate lines
-    "object-property-newline": 0,
+    "object-property-newline": "off",
     // allow just one var statement per function
-    "one-var": 0,
+    "one-var": "off",
     // require or disallow an newline around variable declarations
-    "one-var-declaration-per-line": 0,
+    "one-var-declaration-per-line": "off",
     // require assignment operator shorthand where possible or prohibit it entirely
-    "operator-assignment": 0,
+    "operator-assignment": "off",
     // enforce operators to be placed before or after line breaks
-    "operator-linebreak": 0,
+    "operator-linebreak": "off",
     // enforce padding within blocks
-    "padded-blocks": 0,
+    "padded-blocks": "off",
     // require quotes around object literal property names
-    "quote-props": 0,
+    "quote-props": "off",
     // specify whether double or single quotes should be used
-    "quotes": 0,
+    "quotes": "off",
     // Require JSDoc comment
-    "require-jsdoc": 0,
+    "require-jsdoc": "off",
     // require or disallow use of semicolons instead of ASI
-    "semi": 0,
+    "semi": "off",
     // enforce spacing before and after semicolons
-    "semi-spacing": 0,
+    "semi-spacing": "off",
     // enforce sorting import declarations within module
-    "sort-imports": 0,
+    "sort-imports": "off",
     // sort variables within the same declaration block
-    "sort-vars": 0,
+    "sort-vars": "off",
     // require or disallow space before blocks
-    "space-before-blocks": 0,
+    "space-before-blocks": "off",
     // require or disallow space before function opening parenthesis
-    "space-before-function-paren": 0,
+    "space-before-function-paren": "off",
     // require or disallow spaces inside parentheses
-    "space-in-parens": 0,
+    "space-in-parens": "off",
     // require spaces around operators
-    "space-infix-ops": 0,
+    "space-infix-ops": "off",
     // Require or disallow spaces before/after unary operators
-    "space-unary-ops": 0,
+    "space-unary-ops": "off",
     // require or disallow a space immediately following the // or /* in a comment
-    "spaced-comment": 0,
+    "spaced-comment": "off",
     // require regex literals to be wrapped in parentheses
-    "wrap-regex": 0
+    "wrap-regex": "off"
   }
 };

--- a/rules/eslint/style/on.js
+++ b/rules/eslint/style/on.js
@@ -3,144 +3,144 @@
 module.exports = {
   "rules": {
     // enforce spacing inside array brackets
-    "array-bracket-spacing": 0,
+    "array-bracket-spacing": "off",
     // disallow or enforce spaces inside of single line blocks
-    "block-spacing": 0,
+    "block-spacing": "off",
     // enforce one true brace style
-    "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+    "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
     // require camel case names
-    "camelcase": 2,
+    "camelcase": "error",
     // enforce spacing before and after comma
-    "comma-spacing": 2,
+    "comma-spacing": "error",
     // enforce one true comma style
-    "comma-style": [2, "last"],
+    "comma-style": ["error", "last"],
     // require or disallow padding inside computed properties
-    "computed-property-spacing": [0, "never"],
+    "computed-property-spacing": ["off", "never"],
     // enforces consistent naming when capturing the current execution context
-    "consistent-this": [2, "self"],
+    "consistent-this": ["error", "self"],
     // enforce newline at the end of file, with no multiple empty lines
-    "eol-last": 2,
+    "eol-last": "error",
     // require function expressions to have a name
-    "func-names": 0,
+    "func-names": "off",
     // enforces use of function declarations or expressions
-    "func-style": [2, "expression"],
+    "func-style": ["error", "expression"],
     // disallow certain identifiers to prevent them being used
-    "id-blacklist": 0,
+    "id-blacklist": "off",
     // this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-    "id-length": 0,
+    "id-length": "off",
     // require identifiers to match the provided regular expression
-    "id-match": 0,
+    "id-match": "off",
     // this option sets a specific tab width for your code
-    "indent": [2, 2],
+    "indent": ["error", 2],
     // specify whether double or single quotes should be used in JSX attributes
-    "jsx-quotes": [2, "prefer-double"],
+    "jsx-quotes": ["error", "prefer-double"],
     // enforces spacing between keys and values in object literal properties
-    "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
+    "key-spacing": ["error", { "beforeColon": false, "afterColon": true }],
     // enforce spacing before and after keywords
-    "keyword-spacing": [2, { "before": true, "after": true }],
+    "keyword-spacing": ["error", { "before": true, "after": true }],
     // disallow mixed "LF" and "CRLF" as linebreaks
-    "linebreak-style": [0, "unix"],
+    "linebreak-style": ["off", "unix"],
     // enforces empty lines around comments
-    "lines-around-comment": 0,
+    "lines-around-comment": "off",
     // specify the maximum depth that blocks can be nested
-    "max-depth": [2, 4],
+    "max-depth": ["error", 4],
     // specify the maximum length of a line in your program
-    "max-len": [2, 100, 2, { "ignoreUrls": true, "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(" }],
+    "max-len": ["error", 100, 2, { "ignoreUrls": true, "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(" }],
     // specify the maximum depth callbacks can be nested
-    "max-nested-callbacks": [2, 3],
+    "max-nested-callbacks": ["error", 3],
     // limits the number of parameters that can be used in the function declaration.
-    "max-params": [2, 3],
+    "max-params": ["error", 3],
     // specify the maximum number of statement allowed in a function
-    "max-statements": [2, 15],
+    "max-statements": ["error", 15],
     // specify the maximum number of statements allowed per line
-    "max-statements-per-line": 0,
+    "max-statements-per-line": "off",
     // require a capital letter for constructors
-    "new-cap": 2,
+    "new-cap": "error",
     // disallow the omission of parentheses when invoking a constructor with no arguments
-    "new-parens": 2,
+    "new-parens": "error",
     // allow/disallow an empty newline after var statement
-    "newline-after-var": 0,
+    "newline-after-var": "off",
     // require newline before return statement
-    "newline-before-return": 0,
+    "newline-before-return": "off",
     // enforce newline after each call when chaining the calls
-    "newline-per-chained-call": 0,
+    "newline-per-chained-call": "off",
     // disallow use of the Array constructor
-    "no-array-constructor": 2,
+    "no-array-constructor": "error",
     // disallow use of bitwise operators
-    "no-bitwise": 2,
+    "no-bitwise": "error",
     // disallow use of the continue statement
-    "no-continue": 0,
+    "no-continue": "off",
     // disallow comments inline after code
-    "no-inline-comments": 0,
+    "no-inline-comments": "off",
     // disallow if as the only statement in an else block
-    "no-lonely-if": 2,
+    "no-lonely-if": "error",
     // disallow mixed spaces and tabs for indentation
-    "no-mixed-spaces-and-tabs": 2,
+    "no-mixed-spaces-and-tabs": "error",
     // disallow multiple empty lines
-    "no-multiple-empty-lines": [2, { "max": 2 }],
+    "no-multiple-empty-lines": ["error", { "max": 2 }],
     // disallow negated conditions
-    "no-negated-condition": 0,
+    "no-negated-condition": "off",
     // disallow nested ternary expressions
-    "no-nested-ternary": 2,
+    "no-nested-ternary": "error",
     // disallow use of the Object constructor
-    "no-new-object": 2,
+    "no-new-object": "error",
     // disallow use of unary operators, ++ and --
-    "no-plusplus": 0,
+    "no-plusplus": "off",
     // disallow use of certain syntax in code
-    "no-restricted-syntax": 0,
+    "no-restricted-syntax": "off",
     // disallow space between function identifier and application
-    "no-spaced-func": 2,
+    "no-spaced-func": "error",
     // disallow the use of ternary operators
-    "no-ternary": 0,
+    "no-ternary": "off",
     // disallow trailing whitespace at the end of lines
-    "no-trailing-spaces": 2,
+    "no-trailing-spaces": "error",
     // disallow dangling underscores in identifiers
-    "no-underscore-dangle": 0,
+    "no-underscore-dangle": "off",
     // disallow the use of Boolean literals in conditional expressions
-    "no-unneeded-ternary": 0,
+    "no-unneeded-ternary": "off",
     // disallow whitespace before properties
-    "no-whitespace-before-property": 0,
+    "no-whitespace-before-property": "off",
     // require or disallow padding inside curly braces
     "object-curly-spacing": ["error", "always"],
     // enforce placing object properties on separate lines
-    "object-property-newline": 0,
+    "object-property-newline": "off",
     // allow just one var statement per function
-    "one-var": [2, "never"],
+    "one-var": ["error", "never"],
     // require or disallow an newline around variable declarations
-    "one-var-declaration-per-line": 0,
+    "one-var-declaration-per-line": "off",
     // require assignment operator shorthand where possible or prohibit it entirely
-    "operator-assignment": [2, "always"],
+    "operator-assignment": ["error", "always"],
     // enforce operators to be placed before or after line breaks
-    "operator-linebreak": 0,
+    "operator-linebreak": "off",
     // enforce padding within blocks
-    "padded-blocks": 0,
+    "padded-blocks": "off",
     // require quotes around object literal property names
-    "quote-props": 0,
+    "quote-props": "off",
     // specify whether double or single quotes should be used
-    "quotes": [2, "double"],
+    "quotes": ["error", "double"],
     // Require JSDoc comment
-    "require-jsdoc": 0,
+    "require-jsdoc": "off",
     // require or disallow use of semicolons instead of ASI
-    "semi": 2,
+    "semi": "error",
     // enforce spacing before and after semicolons
-    "semi-spacing": [2, { "before": false, "after": true }],
+    "semi-spacing": ["error", { "before": false, "after": true }],
     // enforce sorting import declarations within module
-    "sort-imports": 0,
+    "sort-imports": "off",
     // sort variables within the same declaration block
-    "sort-vars": 0,
+    "sort-vars": "off",
     // require or disallow space before blocks
-    "space-before-blocks": [2, "always"],
+    "space-before-blocks": ["error", "always"],
     // require or disallow space before function opening parenthesis
-    "space-before-function-paren": [2, { "anonymous": "always", "named": "never" }],
+    "space-before-function-paren": ["error", { "anonymous": "always", "named": "never" }],
     // require or disallow spaces inside parentheses
-    "space-in-parens": [2, "never"],
+    "space-in-parens": ["error", "never"],
     // require spaces around operators
-    "space-infix-ops": 2,
+    "space-infix-ops": "error",
     // Require or disallow spaces before/after unary operators
-    "space-unary-ops": [2, { "words": true, "nonwords": false }],
+    "space-unary-ops": ["error", { "words": true, "nonwords": false }],
     // require or disallow a space immediately following the // or /* in a comment
-    "spaced-comment": 0,
+    "spaced-comment": "off",
     // require regex literals to be wrapped in parentheses
-    "wrap-regex": 0
+    "wrap-regex": "off"
   }
 };

--- a/rules/eslint/variables/off.js
+++ b/rules/eslint/variables/off.js
@@ -3,28 +3,28 @@
 module.exports = {
   "rules": {
     // enforce or disallow variable initializations at definition
-    "init-declarations": 0,
+    "init-declarations": "off",
     // disallow the catch clause parameter name being the same as a variable in the outer scope
-    "no-catch-shadow": 0,
+    "no-catch-shadow": "off",
     // disallow deletion of variables
-    "no-delete-var": 0,
+    "no-delete-var": "off",
     // disallow labels that share a name with a variable
-    "no-label-var": 0,
+    "no-label-var": "off",
     // restrict usage of specified global variables
-    "no-restricted-globals": 0,
+    "no-restricted-globals": "off",
     // disallow declaration of variables already declared in the outer scope
-    "no-shadow": 0,
+    "no-shadow": "off",
     // disallow shadowing of names such as arguments
-    "no-shadow-restricted-names": 0,
+    "no-shadow-restricted-names": "off",
     // disallow use of undeclared variables unless mentioned in a /*global */ block
-    "no-undef": 0,
+    "no-undef": "off",
     // disallow use of undefined when initializing variables
-    "no-undef-init": 0,
+    "no-undef-init": "off",
     // disallow use of undefined variable
-    "no-undefined": 0,
+    "no-undefined": "off",
     // disallow declaration of variables that are not used in the code
-    "no-unused-vars": 0,
+    "no-unused-vars": "off",
     // disallow use of variables before they are defined
-    "no-use-before-define": 0
+    "no-use-before-define": "off"
   }
 };

--- a/rules/eslint/variables/on.js
+++ b/rules/eslint/variables/on.js
@@ -3,28 +3,28 @@
 module.exports = {
   "rules": {
     // enforce or disallow variable initializations at definition
-    "init-declarations": 0,
+    "init-declarations": "off",
     // disallow the catch clause parameter name being the same as a variable in the outer scope
-    "no-catch-shadow": 2,
+    "no-catch-shadow": "error",
     // disallow deletion of variables
-    "no-delete-var": 2,
+    "no-delete-var": "error",
     // disallow labels that share a name with a variable
-    "no-label-var": 2,
+    "no-label-var": "error",
     // restrict usage of specified global variables
-    "no-restricted-globals": 0,
+    "no-restricted-globals": "off",
     // disallow declaration of variables already declared in the outer scope
-    "no-shadow": 2,
+    "no-shadow": "error",
     // disallow shadowing of names such as arguments
-    "no-shadow-restricted-names": 2,
+    "no-shadow-restricted-names": "error",
     // disallow use of undeclared variables unless mentioned in a /*global */ block
-    "no-undef": 2,
+    "no-undef": "error",
     // disallow use of undefined when initializing variables
-    "no-undef-init": 2,
+    "no-undef-init": "error",
     // disallow use of undefined variable
-    "no-undefined": 0,
+    "no-undefined": "off",
     // disallow declaration of variables that are not used in the code
-    "no-unused-vars": [2, { "vars": "all", "args": "after-used" }],
+    "no-unused-vars": ["error", { "vars": "all", "args": "after-used" }],
     // disallow use of variables before they are defined
-    "no-use-before-define": 2
+    "no-use-before-define": "error"
   }
 };

--- a/rules/filenames/off.js
+++ b/rules/filenames/off.js
@@ -6,10 +6,10 @@ module.exports = {
   ],
   "rules": {
     // Enforce dash-cased filenames
-    "filenames/match-regex": 0,
+    "filenames/match-regex": "off",
     // Match the file name against the default exported value in the module
-    "filenames/match-exported": 0,
+    "filenames/match-exported": "off",
     // Don't allow index.js files
-    "filenames/no-index": 0
+    "filenames/no-index": "off"
   }
 };

--- a/rules/filenames/on.js
+++ b/rules/filenames/on.js
@@ -6,10 +6,10 @@ module.exports = {
   ],
   "rules": {
     // Enforce dash-cased filenames
-    "filenames/match-regex": [2, "^[a-z0-9\\-\\.]+$", true],
+    "filenames/match-regex": ["error", "^[a-z0-9\\-\\.]+$", true],
     // Match the file name against the default exported value in the module
-    "filenames/match-exported": 0,
+    "filenames/match-exported": "off",
     // Don't allow index.js files
-    "filenames/no-index": 0
+    "filenames/no-index": "off"
   }
 };

--- a/rules/import/off.js
+++ b/rules/import/off.js
@@ -6,46 +6,46 @@ module.exports = {
   ],
   "rules": {
     // Ensure imports point to a file/module that can be resolved
-    "import/no-unresolved": 0,
+    "import/no-unresolved": "off",
     //Ensure named imports correspond to a named export in the remote file
-    "import/named": 0,
+    "import/named": "off",
     // Ensure a default export is present, given a default import
-    "import/default": 0,
+    "import/default": "off",
     //Ensure imported namespaces contain dereferenced properties as they are dereferenced
-    "import/namespace": 0,
+    "import/namespace": "off",
     //Restrict which files can be imported in a given folder
-    "import/no-restricted-paths": 0,
+    "import/no-restricted-paths": "off",
     // Report any invalid exports, i.e. re-export of the same name
-    "import/export": 0,
+    "import/export": "off",
     //Report use of exported name as identifier of default export
-    "import/no-named-as-default": 0,
+    "import/no-named-as-default": "off",
     //Report use of exported name as property of default export
-    "import/no-named-as-default-member": 0,
+    "import/no-named-as-default-member": "off",
     //Report imported names marked with @deprecated documentation tag
-    "import/no-deprecated": 0,
+    "import/no-deprecated": "off",
     // Forbid the use of extraneous packages
-    "import/no-extraneous-dependencies": 0,
+    "import/no-extraneous-dependencies": "off",
     // Forbid the use of mutable exports with var or let
-    "import/no-mutable-exports": 0,
+    "import/no-mutable-exports": "off",
     //Report CommonJS require calls and module.exports or exports.*
-    "import/no-commonjs": 0,
+    "import/no-commonjs": "off",
     //Report AMD require and define calls.
-    "import/no-amd": 0,
+    "import/no-amd": "off",
     //No Node.js builtin modules
-    "import/no-nodejs-modules": 0,
+    "import/no-nodejs-modules": "off",
     // Ensure all imports appear before other statements
-    "import/imports-first": 0,
+    "import/imports-first": "off",
     // Report repeated import of the same module in multiple places
-    "import/no-duplicates": 0,
+    "import/no-duplicates": "off",
     //Report namespace imports
-    "import/no-namespace": 0,
+    "import/no-namespace": "off",
     //Ensure consistent use of file extension within the import path
-    "import/extensions": 0,
+    "import/extensions": "off",
     //Enforce a convention in module import order
-    "import/order": 0,
+    "import/order": "off",
     //Enforce a newline after import statements
-    "import/newline-after-import": 0,
+    "import/newline-after-import": "off",
     //Prefer a default export if module exports a single name
-    "import/prefer-default-export": 0
+    "import/prefer-default-export": "off"
   }
 };

--- a/rules/import/on.js
+++ b/rules/import/on.js
@@ -6,46 +6,46 @@ module.exports = {
   ],
   "rules": {
     // Ensure imports point to a file/module that can be resolved
-    "import/no-unresolved": 2,
+    "import/no-unresolved": "error",
     //Ensure named imports correspond to a named export in the remote file
-    "import/named": 0,
+    "import/named": "off",
     // Ensure a default export is present, given a default import
-    "import/default": 0,
+    "import/default": "off",
     //Ensure imported namespaces contain dereferenced properties as they are dereferenced
-    "import/namespace": 0,
+    "import/namespace": "off",
     //Restrict which files can be imported in a given folder
-    "import/no-restricted-paths": 0,
+    "import/no-restricted-paths": "off",
     // Report any invalid exports, i.e. re-export of the same name
-    "import/export": 2,
+    "import/export": "error",
     //Report use of exported name as identifier of default export
-    "import/no-named-as-default": 0,
+    "import/no-named-as-default": "off",
     //Report use of exported name as property of default export
-    "import/no-named-as-default-member": 0,
+    "import/no-named-as-default-member": "off",
     //Report imported names marked with @deprecated documentation tag
-    "import/no-deprecated": 0,
+    "import/no-deprecated": "off",
     // Forbid the use of extraneous packages
-    "import/no-extraneous-dependencies": 0,
+    "import/no-extraneous-dependencies": "off",
     // Forbid the use of mutable exports with var or let
-    "import/no-mutable-exports": 2,
+    "import/no-mutable-exports": "error",
     //Report CommonJS require calls and module.exports or exports.*
-    "import/no-commonjs": 0,
+    "import/no-commonjs": "off",
     //Report AMD require and define calls.
-    "import/no-amd": 0,
+    "import/no-amd": "off",
     //No Node.js builtin modules
-    "import/no-nodejs-modules": 0,
+    "import/no-nodejs-modules": "off",
     // Ensure all imports appear before other statements
-    "import/imports-first": 2,
+    "import/imports-first": "error",
     // Report repeated import of the same module in multiple places
-    "import/no-duplicates": 2,
+    "import/no-duplicates": "error",
     //Report namespace imports
-    "import/no-namespace": 0,
+    "import/no-namespace": "off",
     //Ensure consistent use of file extension within the import path
-    "import/extensions": 0,
+    "import/extensions": "off",
     //Enforce a convention in module import order
-    "import/order": 0,
+    "import/order": "off",
     //Enforce a newline after import statements
-    "import/newline-after-import": 0,
+    "import/newline-after-import": "off",
     //Prefer a default export if module exports a single name
-    "import/prefer-default-export": 0
+    "import/prefer-default-export": "off"
   }
 };

--- a/rules/react/off.js
+++ b/rules/react/off.js
@@ -6,103 +6,103 @@ module.exports = {
   ],
   "rules": {
     // Prevent missing displayName in a React component definition
-    "react/display-name": 0,
+    "react/display-name": "off",
     // Forbid certain propTypes
-    "react/forbid-prop-types": 0,
+    "react/forbid-prop-types": "off",
     // Prevent usage of dangerous JSX properties
-    "react/no-danger": 0,
+    "react/no-danger": "off",
     // Prevent usage of deprecated methods
-    "react/no-deprecated": 0,
+    "react/no-deprecated": "off",
     // Prevent usage of setState in componentDidMount
-    "react/no-did-mount-set-state": 0,
+    "react/no-did-mount-set-state": "off",
     // Prevent usage of setState in componentDidUpdate
-    "react/no-did-update-set-state": 0,
+    "react/no-did-update-set-state": "off",
     // Prevent direct mutation of this.state
-    "react/no-direct-mutation-state": 0,
+    "react/no-direct-mutation-state": "off",
     // Prevent usage of findDOMNode
-    "react/no-find-dom-node": 0,
+    "react/no-find-dom-node": "off",
     // Prevent usage of isMounted
-    "react/no-is-mounted": 0,
+    "react/no-is-mounted": "off",
     // Prevent multiple component definition per file
-    "react/no-multi-comp": 0,
+    "react/no-multi-comp": "off",
     // Prevent usage of the return value of React.render
-    "react/no-render-return-value": 0,
+    "react/no-render-return-value": "off",
     // Prevent usage of setState
-    "react/no-set-state": 0,
+    "react/no-set-state": "off",
     // Prevent using string references in ref attribute.
-    "react/no-string-refs": 0,
+    "react/no-string-refs": "off",
     // Prevent usage of unknown DOM property
-    "react/no-unknown-property": 0,
+    "react/no-unknown-property": "off",
     // Enforce ES5 or ES6 class for React Components
-    "react/prefer-es6-class": 0,
+    "react/prefer-es6-class": "off",
     // Enforce stateless React Components to be written as a pure function
-    "react/prefer-stateless-function": 0,
+    "react/prefer-stateless-function": "off",
     // Prevent missing props validation in a React component definition
-    "react/prop-types": 0,
+    "react/prop-types": "off",
     // Prevent missing React when using JSX
-    "react/react-in-jsx-scope": 0,
+    "react/react-in-jsx-scope": "off",
     // Restrict file extensions that may be required
-    "react/require-extension": 0,
+    "react/require-extension": "off",
     // Enforce React components to have a shouldComponentUpdate method
-    "react/require-optimization": 0,
+    "react/require-optimization": "off",
     // Enforce ES5 or ES6 class for returning value in render function
-    "react/require-render-return": 0,
+    "react/require-render-return": "off",
     // Prevent extra closing tags for components without children
-    "react/self-closing-comp": 0,
+    "react/self-closing-comp": "off",
     // Enforce component methods order
-    "react/sort-comp": 0,
+    "react/sort-comp": "off",
     // Enforce propTypes declarations alphabetical sorting
-    "react/sort-prop-types": 0,
+    "react/sort-prop-types": "off",
 
     // ========================================================================
     //                                JSX Specific Rules
     // ========================================================================
 
     // Enforce boolean attributes notation in JSX
-    "react/jsx-boolean-value": 0,
+    "react/jsx-boolean-value": "off",
     // Validate closing bracket location in JSX
-    "react/jsx-closing-bracket-location": 0,
+    "react/jsx-closing-bracket-location": "off",
     // Enforce or disallow spaces inside of curly braces in JSX attributes
-    "react/jsx-curly-spacing": 0,
+    "react/jsx-curly-spacing": "off",
     // Enforce or disallow spaces around equal signs in JSX attributes (fixable)
-    "react/jsx-equals-spacing": 0,
+    "react/jsx-equals-spacing": "off",
     // Restrict file extensions that may contain JSX
-    "react/jsx-filename-extension": 0,
+    "react/jsx-filename-extension": "off",
     // Enforce position of the first prop in JSX
-    "react/jsx-first-prop-new-line": 0,
+    "react/jsx-first-prop-new-line": "off",
     // Enforce event handler naming conventions in JSX
-    "react/jsx-handler-names": 0,
+    "react/jsx-handler-names": "off",
     // Validate JSX indentation
-    "react/jsx-indent": 0,
+    "react/jsx-indent": "off",
     // Validate props indentation in JSX
-    "react/jsx-indent-props": 0,
+    "react/jsx-indent-props": "off",
     // Validate JSX has key prop when in array or iterator
-    "react/jsx-key": 0,
+    "react/jsx-key": "off",
     // Limit maximum of props on a single line in JSX
-    "react/jsx-max-props-per-line": 0,
+    "react/jsx-max-props-per-line": "off",
     // Prevent usage of .bind() and arrow functions in JSX props
-    "react/jsx-no-bind": 0,
+    "react/jsx-no-bind": "off",
     // Prevent comments from being inserted as text nodes
-    "react/jsx-no-comment-textnodes": 0,
+    "react/jsx-no-comment-textnodes": "off",
     // Prevent duplicate props in JSX
-    "react/jsx-no-duplicate-props": 0,
+    "react/jsx-no-duplicate-props": "off",
     // Prevent usage of unwrapped JSX strings
-    "react/jsx-no-literals": 0,
+    "react/jsx-no-literals": "off",
     // Prevent usage of unsafe target='_blank'
-    "react/jsx-no-target-blank": 0,
+    "react/jsx-no-target-blank": "off",
     // Disallow undeclared variables in JSX
-    "react/jsx-no-undef": 0,
+    "react/jsx-no-undef": "off",
     // Enforce PascalCase for user-defined JSX components
-    "react/jsx-pascal-case": 0,
+    "react/jsx-pascal-case": "off",
     // Enforce props alphabetical sorting
-    "react/jsx-sort-props": 0,
+    "react/jsx-sort-props": "off",
     // Validate spacing before closing bracket in JSX (fixable)
-    "react/jsx-space-before-closing": 0,
+    "react/jsx-space-before-closing": "off",
     // Prevent React to be incorrectly marked as unused
-    "react/jsx-uses-react": 0,
+    "react/jsx-uses-react": "off",
     // Prevent variables used in JSX to be incorrectly marked as unused
-    "react/jsx-uses-vars": 0,
+    "react/jsx-uses-vars": "off",
     // Prevent missing parentheses around multilines JSX
-    "react/jsx-wrap-multilines": 0
+    "react/jsx-wrap-multilines": "off"
   }
 };

--- a/rules/react/on.js
+++ b/rules/react/on.js
@@ -6,103 +6,103 @@ module.exports = {
   ],
   "rules": {
     // Prevent missing displayName in a React component definition
-    "react/display-name": 0,
+    "react/display-name": "off",
     // Forbid certain propTypes
-    "react/forbid-prop-types": 0,
+    "react/forbid-prop-types": "off",
     // Prevent usage of dangerous JSX properties
-    "react/no-danger": 0,
+    "react/no-danger": "off",
     // Prevent usage of deprecated methods
-    "react/no-deprecated": 2,
+    "react/no-deprecated": "error",
     // Prevent usage of setState in componentDidMount
-    "react/no-did-mount-set-state": 2,
+    "react/no-did-mount-set-state": "error",
     // Prevent usage of setState in componentDidUpdate
-    "react/no-did-update-set-state": 2,
+    "react/no-did-update-set-state": "error",
     // Prevent direct mutation of this.state
-    "react/no-direct-mutation-state": 2,
+    "react/no-direct-mutation-state": "error",
     // Prevent usage of findDOMNode
-    "react/no-find-dom-node": 1,
+    "react/no-find-dom-node": "warn",
     // Prevent usage of isMounted
-    "react/no-is-mounted": 2,
+    "react/no-is-mounted": "error",
     // Prevent multiple component definition per file
-    "react/no-multi-comp": 2,
+    "react/no-multi-comp": "error",
     // Prevent usage of the return value of React.render
-    "react/no-render-return-value": 0,
+    "react/no-render-return-value": "off",
     // Prevent usage of setState
-    "react/no-set-state": 0,
+    "react/no-set-state": "off",
     // Prevent using string references in ref attribute.
-    "react/no-string-refs": 2,
+    "react/no-string-refs": "error",
     // Prevent usage of unknown DOM property
-    "react/no-unknown-property": 2,
+    "react/no-unknown-property": "error",
     // Enforce ES5 or ES6 class for React Components
-    "react/prefer-es6-class": 2,
+    "react/prefer-es6-class": "error",
     // Enforce stateless React Components to be written as a pure function
-    "react/prefer-stateless-function": 0,
+    "react/prefer-stateless-function": "off",
     // Prevent missing props validation in a React component definition
-    "react/prop-types": 2,
+    "react/prop-types": "error",
     // Prevent missing React when using JSX
-    "react/react-in-jsx-scope": 2,
+    "react/react-in-jsx-scope": "error",
     // Restrict file extensions that may be required
-    "react/require-extension": 0,
+    "react/require-extension": "off",
     // Enforce React components to have a shouldComponentUpdate method
-    "react/require-optimization": 0,
+    "react/require-optimization": "off",
     // Enforce ES5 or ES6 class for returning value in render function
-    "react/require-render-return": 0,
+    "react/require-render-return": "off",
     // Prevent extra closing tags for components without children
-    "react/self-closing-comp": 2,
+    "react/self-closing-comp": "error",
     // Enforce component methods order
-    "react/sort-comp": 2,
+    "react/sort-comp": "error",
     // Enforce propTypes declarations alphabetical sorting
-    "react/sort-prop-types": 2,
+    "react/sort-prop-types": "error",
 
     // ========================================================================
     //                                JSX Specific Rules
     // ========================================================================
 
     // Enforce boolean attributes notation in JSX
-    "react/jsx-boolean-value": 2,
+    "react/jsx-boolean-value": "error",
     // Validate closing bracket location in JSX
-    "react/jsx-closing-bracket-location": [2, "tag-aligned"],
+    "react/jsx-closing-bracket-location": ["error", "tag-aligned"],
     // Enforce or disallow spaces inside of curly braces in JSX attributes
-    "react/jsx-curly-spacing": 0,
+    "react/jsx-curly-spacing": "off",
     // Enforce or disallow spaces around equal signs in JSX attributes (fixable)
-    "react/jsx-equals-spacing": 0,
+    "react/jsx-equals-spacing": "off",
     // Restrict file extensions that may contain JSX
-    "react/jsx-filename-extension": 0,
+    "react/jsx-filename-extension": "off",
     // Enforce position of the first prop in JSX
-    "react/jsx-first-prop-new-line": 0,
+    "react/jsx-first-prop-new-line": "off",
     // Enforce event handler naming conventions in JSX
-    "react/jsx-handler-names": 1,
+    "react/jsx-handler-names": "warn",
     // Validate JSX indentation
-    "react/jsx-indent": 0,
+    "react/jsx-indent": "off",
     // Validate props indentation in JSX
-    "react/jsx-indent-props": [2, 2],
+    "react/jsx-indent-props": ["error", 2],
     // Validate JSX has key prop when in array or iterator
-    "react/jsx-key": 2,
+    "react/jsx-key": "error",
     // Limit maximum of props on a single line in JSX
-    "react/jsx-max-props-per-line": 0,
+    "react/jsx-max-props-per-line": "off",
     // Prevent usage of .bind() and arrow functions in JSX props
-    "react/jsx-no-bind": 0,
+    "react/jsx-no-bind": "off",
     // Prevent comments from being inserted as text nodes
-    "react/jsx-no-comment-textnodes": 0,
+    "react/jsx-no-comment-textnodes": "off",
     // Prevent duplicate props in JSX
-    "react/jsx-no-duplicate-props": 0,
+    "react/jsx-no-duplicate-props": "off",
     // Prevent usage of unwrapped JSX strings
-    "react/jsx-no-literals": 0,
+    "react/jsx-no-literals": "off",
     // Prevent usage of unsafe target='_blank'
-    "react/jsx-no-target-blank": 0,
+    "react/jsx-no-target-blank": "off",
     // Disallow undeclared variables in JSX
-    "react/jsx-no-undef": 2,
+    "react/jsx-no-undef": "error",
     // Enforce PascalCase for user-defined JSX components
-    "react/jsx-pascal-case": 2,
+    "react/jsx-pascal-case": "error",
     // Enforce propTypes declarations alphabetical sorting
-    "react/jsx-sort-props": 0,
+    "react/jsx-sort-props": "off",
     // Validate spacing before closing bracket in JSX (fixable)
-    "react/jsx-space-before-closing": 0,
+    "react/jsx-space-before-closing": "off",
     // Prevent React to be incorrectly marked as unused
-    "react/jsx-uses-react": 2,
+    "react/jsx-uses-react": "error",
     // Prevent variables used in JSX to be incorrectly marked as unused
-    "react/jsx-uses-vars": 2,
+    "react/jsx-uses-vars": "error",
     // Prevent missing parentheses around multilines JSX
-    "react/jsx-wrap-multilines": 2
+    "react/jsx-wrap-multilines": "error"
   }
 };


### PR DESCRIPTION
This PR converts all rules that are defined with ints to strings. The changes are applied to `/rules` as well as `/configurations`. This is the recommended style and fixes any inconsistencies in rule-usage. Non-breaking.

closes #13

`"0" -> "off"`

`"1" -> "warn"`

`"2" -> "error"`

cc @baer @ryan-roemer 
