### PR TITLE
[MAJOR] Update filenames/match-regex to always enforce.

### DIFF
--- a/rules/filenames/on.js
+++ b/rules/filenames/on.js
@@ -6,8 +6,10 @@ module.exports = {
   ],
   "rules": {
     // Enforce dash-cased filenames
-    "filenames/match-regex": ["error", "^[a-z0-9\\-\\.]+$", true],
+    // `true` here means "don't enforce if `export` exists in file"
+    "filenames/match-regex": ["error", "^[a-z0-9\\-\\.]+$", false],
     // Match the file name against the default exported value in the module
+    // Should set to `"error"` if last parameter above is `true`.
     "filenames/match-exported": "off",
     // Don't allow index.js files
     "filenames/no-index": "off"

--- a/rules/filenames/on.js
+++ b/rules/filenames/on.js
@@ -6,7 +6,7 @@ module.exports = {
   ],
   "rules": {
     // Enforce dash-cased filenames
-    // `true` here means "don't enforce if `export` exists in file"
+    // `true` here means "don't enforce if `export default` exists in file"
     "filenames/match-regex": ["error", "^[a-z0-9\\-\\.]+$", false],
     // Match the file name against the default exported value in the module
     // Should set to `"error"` if last parameter above is `true`.


### PR DESCRIPTION
We have an awkward bug wherein if a JS file has an `export default` anywhere in it, then filename checking is _completely disabled_.
- Marking as `MAJOR` because will cause breakage in existing projects.
- Default to `false` (strict checking)
- Add comments to hint for esnext folks that want camelCase names matching exports.

/cc @baer @jevakallio @Aweary 
