### PR TITLE
Update to latest eslint version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 # App Files
 # --------------------
 node_modules
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4.2"
-  - "5.0"
+  - "4"
+  - "6"
 
 # Use container-based Travis infrastructure.
 sudo: false

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Due to an issue with ESLint, config extension cannot be called from a globally i
 
 ### This package tracks config in the following versions:
 
-- [ESLint](https://github.com/eslint/eslint) 2.10.2
+- [ESLint](https://github.com/eslint/eslint) 3.19.0
 - [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react) 6.0.0
 - [eslint-plugin-filenames](https://www.npmjs.com/package/eslint-plugin-filenames) 1.1.0
 - [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import) 1.13.0

--- a/configurations/es6-node.js
+++ b/configurations/es6-node.js
@@ -24,8 +24,6 @@ module.exports = {
     "no-dupe-class-members": "off",
     // disallow to use this/super before super() calling in constructors.
     "no-this-before-super": "off",
-    // suggest using Reflect methods where applicable
-    "prefer-reflect": "off",
     // require that all functions are run in strict mode
     "strict": ["error", "global"]
   }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "private": false,
   "dependencies": {},
   "devDependencies": {
-    "babel-eslint": "6.1.2",
-    "eslint": "^2.10.2",
+    "babel-eslint": "7.2.3",
+    "eslint": "3.19.0",
     "eslint-plugin-filenames": "1.1.0",
     "eslint-plugin-import": "1.13.0",
     "eslint-plugin-react": "6.0.0"

--- a/rules/eslint/best-practices/off.js
+++ b/rules/eslint/best-practices/off.js
@@ -8,6 +8,8 @@ module.exports = {
     "array-callback-return": "off",
     // treat var statements as if they were block scoped
     "block-scoped-var": "off",
+    // enforce that class methods utilize this
+    "class-methods-use-this": "off",
     // specify the maximum cyclomatic complexity allowed in a program
     "complexity": "off",
     // require return statements to either always or never specify values
@@ -52,6 +54,8 @@ module.exports = {
     "no-fallthrough": "off",
     // disallow the use of leading or trailing decimal points in numeric literals
     "no-floating-decimal": "off",
+    // disallow assignments to native objects or read-only global variables
+    "no-global-assign": "off",
     // disallow the type conversions with shorter notations
     "no-implicit-coercion": "off",
     // disallow var and named functions in global scope
@@ -74,8 +78,6 @@ module.exports = {
     "no-multi-spaces": "off",
     // disallow use of multiline strings
     "no-multi-str": "off",
-    // disallow reassignments of native objects
-    "no-native-reassign": "off",
     // disallow use of new operator when not part of the assignment or comparison
     "no-new": "off",
     // disallow use of new operator for Function object
@@ -93,8 +95,12 @@ module.exports = {
     "no-proto": "off",
     // disallow declaring the same variable more then once
     "no-redeclare": "off",
+    // disallow certain properties on certain objects
+    "no-restricted-properties": "off",
     // disallow use of assignment in return statement
     "no-return-assign": "off",
+    // disallow unnecessary return await
+    "no-return-await": "off",
     // disallow use of `javascript:` urls.
     "no-script-url": "off",
     // disallow assignments where both sides are exactly the same
@@ -117,14 +123,20 @@ module.exports = {
     "no-useless-concat": "off",
     // disallow unnecessary usage of escape character
     "no-useless-escape": "off",
+    // disallow redundant return statements
+    "no-useless-return": "off",
     // disallow use of void operator
     "no-void": "off",
     // disallow usage of configurable warning terms in comments: e.g. todo
     "no-warning-comments": "off",
     // disallow use of the with statement
     "no-with": "off",
+    // require using Error objects as Promise rejection reasons
+    "prefer-promise-reject-errors": "off",
     // require use of the second argument for parseInt()
     "radix": "off",
+    // disallow async functions which have no await expression
+    "require-await": "off",
     // requires to declare all vars on top of their containing scope
     "vars-on-top": "off",
     // require immediate function invocation to be wrapped in parentheses

--- a/rules/eslint/best-practices/on.js
+++ b/rules/eslint/best-practices/on.js
@@ -8,6 +8,8 @@ module.exports = {
     "array-callback-return": "off",
     // treat var statements as if they were block scoped
     "block-scoped-var": "off",
+    // enforce that class methods utilize this
+    "class-methods-use-this": "off",
     // specify the maximum cyclomatic complexity allowed in a program
     "complexity": ["error", 11],
     // require return statements to either always or never specify values
@@ -52,6 +54,8 @@ module.exports = {
     "no-fallthrough": "error",
     // disallow the use of leading or trailing decimal points in numeric literals
     "no-floating-decimal": "off",
+    // disallow assignments to native objects or read-only global variables
+    "no-global-assign": "off",
     // disallow the type conversions with shorter notations
     "no-implicit-coercion": "off",
     // disallow var and named functions in global scope
@@ -74,8 +78,6 @@ module.exports = {
     "no-multi-spaces": "error",
     // disallow use of multiline strings
     "no-multi-str": "error",
-    // disallow reassignments of native objects
-    "no-native-reassign": "error",
     // disallow use of new operator when not part of the assignment or comparison
     "no-new": "error",
     // disallow use of new operator for Function object
@@ -93,8 +95,12 @@ module.exports = {
     "no-proto": "error",
     // disallow declaring the same variable more then once
     "no-redeclare": "error",
+    // disallow certain properties on certain objects
+    "no-restricted-properties": "off",
     // disallow use of assignment in return statement
     "no-return-assign": "error",
+    // disallow unnecessary return await
+    "no-return-await": "off",
     // disallow use of `javascript:` urls.
     "no-script-url": "error",
     // disallow assignments where both sides are exactly the same
@@ -117,14 +123,20 @@ module.exports = {
     "no-useless-concat": "error",
     // disallow unnecessary usage of escape character
     "no-useless-escape": "off",
+    // disallow redundant return statements
+    "no-useless-return": "off",
     // disallow use of void operator
     "no-void": "off",
     // disallow usage of configurable warning terms in comments: e.g. todo
     "no-warning-comments": "off",
     // disallow use of the with statement
     "no-with": "error",
+    // require using Error objects as Promise rejection reasons
+    "prefer-promise-reject-errors": "off",
     // require use of the second argument for parseInt()
     "radix": "off",
+    // disallow async functions which have no await expression
+    "require-await": "off",
     // requires to declare all vars on top of their containing scope
     "vars-on-top": "off",
     // require immediate function invocation to be wrapped in parentheses

--- a/rules/eslint/errors/off.js
+++ b/rules/eslint/errors/off.js
@@ -2,8 +2,10 @@
 
 module.exports = {
   "rules": {
-    // disallow trailing commas in object literals
-    "comma-dangle": "off",
+    // disallow await inside of loops
+    "no-await-in-loop": "off",
+    // disallow comparing against -0
+    "no-compare-neg-zero": "off",
     // disallow assignment in conditional expressions
     "no-cond-assign": "off",
     // disallow use of console
@@ -40,20 +42,24 @@ module.exports = {
     "no-invalid-regexp": "off",
     // disallow irregular whitespace outside of strings and comments
     "no-irregular-whitespace": "off",
-    // disallow negation of the left operand of an in expression
-    "no-negated-in-lhs": "off",
     // disallow the use of object properties of the global object (Math and JSON) as functions
     "no-obj-calls": "off",
+    // disallow calling some Object.prototype methods directly on objects
+    "no-prototype-builtins": "off",
     // disallow multiple spaces in a regular expression literal
     "no-regex-spaces": "off",
     // disallow sparse arrays
     "no-sparse-arrays": "off",
+    // disallow template literal placeholder syntax in regular strings
+    "no-template-curly-in-string": "off",
     // Avoid code that looks like two expressions but is actually one
     "no-unexpected-multiline": "off",
     // disallow unreachable statements after a return, throw, continue, or break statement
     "no-unreachable": "off",
     // disallow control flow statements in finally blocks
     "no-unsafe-finally": "off",
+    // disallow negating the left operand of relational operators
+    "no-unsafe-negation": "off",
     // disallow comparisons with the value NaN
     "use-isnan": "off",
     // ensure JSDoc comments are valid

--- a/rules/eslint/errors/on.js
+++ b/rules/eslint/errors/on.js
@@ -2,8 +2,10 @@
 
 module.exports = {
   "rules": {
-    // disallow trailing commas in object literals
-    "comma-dangle": ["error", "never"],
+    // disallow await inside of loops
+    "no-await-in-loop": "off",
+    // disallow comparing against -0
+    "no-compare-neg-zero": "off",
     // disallow assignment in conditional expressions
     "no-cond-assign": "error",
     // disallow use of console
@@ -40,20 +42,24 @@ module.exports = {
     "no-invalid-regexp": "error",
     // disallow irregular whitespace outside of strings and comments
     "no-irregular-whitespace": "error",
-    // disallow negation of the left operand of an in expression
-    "no-negated-in-lhs": "error",
     // disallow the use of object properties of the global object (Math and JSON) as functions
     "no-obj-calls": "error",
+    // disallow calling some Object.prototype methods directly on objects
+    "no-prototype-builtins": "off",
     // disallow multiple spaces in a regular expression literal
     "no-regex-spaces": "error",
     // disallow sparse arrays
     "no-sparse-arrays": "error",
+    // disallow template literal placeholder syntax in regular strings
+    "no-template-curly-in-string": "off",
     // Avoid code that looks like two expressions but is actually one
     "no-unexpected-multiline": "error",
     // disallow unreachable statements after a return, throw, continue, or break statement
     "no-unreachable": "error",
     // disallow control flow statements in finally blocks
     "no-unsafe-finally": "off",
+    // disallow negating the left operand of relational operators
+    "no-unsafe-negation": "error",
     // disallow comparisons with the value NaN
     "use-isnan": "error",
     // ensure JSDoc comments are valid

--- a/rules/eslint/es6/off.js
+++ b/rules/eslint/es6/off.js
@@ -32,6 +32,8 @@ module.exports = {
     "no-useless-computed-key": "off",
     // disallow unnecessary constructor
     "no-useless-constructor": "off",
+    // disallow renaming import, export, and destructured assignments to the same name
+    "no-useless-rename": "off",
     // require let or const instead of var
     "no-var": "off",
     // require method and property shorthand syntax for object literals
@@ -40,8 +42,10 @@ module.exports = {
     "prefer-arrow-callback": "off",
     // suggest using of const declaration for variables that are never modified after declared
     "prefer-const": "off",
-    // suggest using Reflect methods where applicable
-    "prefer-reflect": "off",
+    // require destructuring from arrays and/or objects
+    "prefer-destructuring": "off",
+    // disallow parseInt() in favor of binary, octal, and hexadecimal literals
+    "prefer-numeric-literals": "off",
     // suggest using the rest parameters instead of arguments
     "prefer-rest-params": "off",
     // suggest using the spread operator instead of .apply()
@@ -50,8 +54,12 @@ module.exports = {
     "prefer-template": "off",
     // disallow generator functions that do not have yield
     "require-yield": "off",
+    // enforce spacing between rest and spread operators and their expressions
+    "rest-spread-spacing": "off",
     // enforce sorted import declarations within modules
     "sort-imports": "off",
+    // require symbol descriptions
+    "symbol-description": "off",
     // enforce spacing around embedded expressions of template strings
     "template-curly-spacing": "off",
     // enforce spacing around the * in yield* expressions

--- a/rules/eslint/es6/on.js
+++ b/rules/eslint/es6/on.js
@@ -32,6 +32,8 @@ module.exports = {
     "no-useless-computed-key": "off",
     // disallow unnecessary constructor
     "no-useless-constructor": "off",
+    // disallow renaming import, export, and destructured assignments to the same name
+    "no-useless-rename": "off",
     // require let or const instead of var
     "no-var": "error",
     // require method and property shorthand syntax for object literals
@@ -40,8 +42,10 @@ module.exports = {
     "prefer-arrow-callback": "warn",
     // suggest using of const declaration for variables that are never modified after declared
     "prefer-const": "error",
-    // suggest using Reflect methods where applicable
-    "prefer-reflect": "off",
+    // require destructuring from arrays and/or objects
+    "prefer-destructuring": "off",
+    // disallow parseInt() in favor of binary, octal, and hexadecimal literals
+    "prefer-numeric-literals": "off",
     // suggest using the rest parameters instead of arguments
     "prefer-rest-params": "off",
     // suggest using the spread operator instead of .apply()
@@ -50,8 +54,12 @@ module.exports = {
     "prefer-template": "warn",
     // disallow generator functions that do not have yield
     "require-yield": "error",
+    // enforce spacing between rest and spread operators and their expressions
+    "rest-spread-spacing": "off",
     // enforce sorted import declarations within modules
     "sort-imports": "off",
+    // require symbol descriptions
+    "symbol-description": "off",
     // enforce spacing around embedded expressions of template strings
     "template-curly-spacing": "off",
     // enforce spacing around the * in yield* expressions

--- a/rules/eslint/style/off.js
+++ b/rules/eslint/style/off.js
@@ -10,6 +10,10 @@ module.exports = {
     "brace-style": "off",
     // require camel case names
     "camelcase": "off",
+    // enforce or disallow capitalization of the first letter of a comment
+    "capitalized-comments": "off",
+    // disallow trailing commas in object literals
+    "comma-dangle": "off",
     // enforce spacing before and after comma
     "comma-spacing": "off",
     // enforce one true comma style
@@ -20,6 +24,10 @@ module.exports = {
     "consistent-this": "off",
     // enforce newline at the end of file, with no multiple empty lines
     "eol-last": "off",
+    // require or disallow spacing between function identifiers and their invocations
+    "func-call-spacing": "off",
+    // require function names to match the name of the variable or property to which they are assigned
+    "func-name-matching": "off",
     // require function expressions to have a name
     "func-names": "off",
     // enforces use of function declarations or expressions
@@ -38,14 +46,20 @@ module.exports = {
     "key-spacing": "off",
     // enforce spacing before and after keywords
     "keyword-spacing": "off",
+    // enforce position of line comments
+    "line-comment-position": "off",
     // disallow mixed "LF" and "CRLF" as linebreaks
     "linebreak-style": "off",
     // enforces empty lines around comments
     "lines-around-comment": "off",
+    // require or disallow newlines around directives
+    "lines-around-directive": "off",
     // specify the maximum depth that blocks can be nested
     "max-depth": "off",
     // specify the maximum length of a line in your program
     "max-len": "off",
+    // enforce a maximum number of lines per file
+    "max-lines": "off",
     // specify the maximum depth callbacks can be nested
     "max-nested-callbacks": "off",
     // limits the number of parameters that can be used in the function declaration.
@@ -54,6 +68,8 @@ module.exports = {
     "max-statements": "off",
     // specify the maximum number of statements allowed per line
     "max-statements-per-line": "off",
+    // enforce newlines between operands of ternary expressions
+    "multiline-ternary": "off",
     // require a capital letter for constructors
     "new-cap": "off",
     // disallow the omission of parentheses when invoking a constructor with no arguments
@@ -74,8 +90,12 @@ module.exports = {
     "no-inline-comments": "off",
     // disallow if as the only statement in an else block
     "no-lonely-if": "off",
+    // disallow mixed binary operators
+    "no-mixed-operators": "off",
     // disallow mixed spaces and tabs for indentation
     "no-mixed-spaces-and-tabs": "off",
+    // disallow use of chained assignment expressions
+    "no-multi-assign": "off",
     // disallow multiple empty lines
     "no-multiple-empty-lines": "off",
     // disallow negated conditions
@@ -88,8 +108,8 @@ module.exports = {
     "no-plusplus": "off",
     // disallow use of certain syntax in code
     "no-restricted-syntax": "off",
-    // disallow space between function identifier and application
-    "no-spaced-func": "off",
+    // disallow all tabs
+    "no-tabs": "off",
     // disallow the use of ternary operators
     "no-ternary": "off",
     // disallow trailing whitespace at the end of lines
@@ -100,6 +120,10 @@ module.exports = {
     "no-unneeded-ternary": "off",
     // disallow whitespace before properties
     "no-whitespace-before-property": "off",
+    // enforce the location of single-line statements
+    "nonblock-statement-body-position": "off",
+    // enforce consistent line breaks inside braces
+    "object-curly-newline": "off",
     // require or disallow padding inside curly braces
     "object-curly-spacing": "off",
     // enforce placing object properties on separate lines
@@ -124,8 +148,8 @@ module.exports = {
     "semi": "off",
     // enforce spacing before and after semicolons
     "semi-spacing": "off",
-    // enforce sorting import declarations within module
-    "sort-imports": "off",
+    // require object keys to be sorted
+    "sort-keys": "off",
     // sort variables within the same declaration block
     "sort-vars": "off",
     // require or disallow space before blocks
@@ -140,6 +164,10 @@ module.exports = {
     "space-unary-ops": "off",
     // require or disallow a space immediately following the // or /* in a comment
     "spaced-comment": "off",
+    // require or disallow spacing between template tags and their literals
+    "template-tag-spacing": "off",
+    // require or disallow Unicode byte order mark (BOM)
+    "unicode-bom": "off",
     // require regex literals to be wrapped in parentheses
     "wrap-regex": "off"
   }

--- a/rules/eslint/style/on.js
+++ b/rules/eslint/style/on.js
@@ -10,6 +10,10 @@ module.exports = {
     "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
     // require camel case names
     "camelcase": "error",
+    // enforce or disallow capitalization of the first letter of a comment
+    "capitalized-comments": "off",
+    // disallow trailing commas in object literals
+    "comma-dangle": ["error", "never"],
     // enforce spacing before and after comma
     "comma-spacing": "error",
     // enforce one true comma style
@@ -20,6 +24,10 @@ module.exports = {
     "consistent-this": ["error", "self"],
     // enforce newline at the end of file, with no multiple empty lines
     "eol-last": "error",
+    // require or disallow spacing between function identifiers and their invocations
+    "func-call-spacing": "off",
+    // require function names to match the name of the variable or property to which they are assigned
+    "func-name-matching": "off",
     // require function expressions to have a name
     "func-names": "off",
     // enforces use of function declarations or expressions
@@ -38,14 +46,20 @@ module.exports = {
     "key-spacing": ["error", { "beforeColon": false, "afterColon": true }],
     // enforce spacing before and after keywords
     "keyword-spacing": ["error", { "before": true, "after": true }],
+    // enforce position of line comments
+    "line-comment-position": "off",
     // disallow mixed "LF" and "CRLF" as linebreaks
     "linebreak-style": ["off", "unix"],
     // enforces empty lines around comments
     "lines-around-comment": "off",
+    // require or disallow newlines around directives
+    "lines-around-directive": "off",
     // specify the maximum depth that blocks can be nested
     "max-depth": ["error", 4],
     // specify the maximum length of a line in your program
     "max-len": ["error", 100, 2, { "ignoreUrls": true, "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(" }],
+    // enforce a maximum number of lines per file
+    "max-lines": "off",
     // specify the maximum depth callbacks can be nested
     "max-nested-callbacks": ["error", 3],
     // limits the number of parameters that can be used in the function declaration.
@@ -54,6 +68,8 @@ module.exports = {
     "max-statements": ["error", 15],
     // specify the maximum number of statements allowed per line
     "max-statements-per-line": "off",
+    // enforce newlines between operands of ternary expressions
+    "multiline-ternary": "off",
     // require a capital letter for constructors
     "new-cap": "error",
     // disallow the omission of parentheses when invoking a constructor with no arguments
@@ -74,8 +90,12 @@ module.exports = {
     "no-inline-comments": "off",
     // disallow if as the only statement in an else block
     "no-lonely-if": "error",
+    // disallow mixed binary operators
+    "no-mixed-operators": "off",
     // disallow mixed spaces and tabs for indentation
     "no-mixed-spaces-and-tabs": "error",
+    // disallow use of chained assignment expressions
+    "no-multi-assign": "off",
     // disallow multiple empty lines
     "no-multiple-empty-lines": ["error", { "max": 2 }],
     // disallow negated conditions
@@ -88,8 +108,8 @@ module.exports = {
     "no-plusplus": "off",
     // disallow use of certain syntax in code
     "no-restricted-syntax": "off",
-    // disallow space between function identifier and application
-    "no-spaced-func": "error",
+    // disallow all tabs
+    "no-tabs": "off",
     // disallow the use of ternary operators
     "no-ternary": "off",
     // disallow trailing whitespace at the end of lines
@@ -100,6 +120,10 @@ module.exports = {
     "no-unneeded-ternary": "off",
     // disallow whitespace before properties
     "no-whitespace-before-property": "off",
+    // enforce the location of single-line statements
+    "nonblock-statement-body-position": "off",
+    // enforce consistent line breaks inside braces
+    "object-curly-newline": "off",
     // require or disallow padding inside curly braces
     "object-curly-spacing": ["error", "always"],
     // enforce placing object properties on separate lines
@@ -124,8 +148,8 @@ module.exports = {
     "semi": "error",
     // enforce spacing before and after semicolons
     "semi-spacing": ["error", { "before": false, "after": true }],
-    // enforce sorting import declarations within module
-    "sort-imports": "off",
+    // require object keys to be sorted
+    "sort-keys": "off",
     // sort variables within the same declaration block
     "sort-vars": "off",
     // require or disallow space before blocks


### PR DESCRIPTION
THis PR updates all of the rules to follow the latest eslint 3.x version. Eslint is just about to release 4.x so there will be a few updates soon after. Note that this PR does not enable any new rules - that will be a follow on PR. I just wanted to get this package up to date with the 3.x line before 4.x goes live. 

@ryan-roemer @kylecesmat 