### PR TITLE
Feature/enable fixable rules

### DIFF
--- a/configurations/es6.js
+++ b/configurations/es6.js
@@ -10,6 +10,7 @@ module.exports = {
     "ecmaVersion": 6,
     "sourceType": "module",
     "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
       "impliedStrict": true
     }
   },

--- a/rules/eslint/best-practices/on.js
+++ b/rules/eslint/best-practices/on.js
@@ -19,7 +19,7 @@ module.exports = {
     // require default case in switch statements
     "default-case": "off",
     // enforces consistent newlines before or after dots
-    "dot-location": "off",
+    "dot-location": ["error", "property"],
     // encourages use of dot notation whenever possible
     "dot-notation": ["error", { "allowKeywords": true }],
     // require the use of === and !==
@@ -35,7 +35,7 @@ module.exports = {
     // disallow division operators explicitly at beginning of regular expression
     "no-div-regex": "off",
     // disallow else after a return in an if
-    "no-else-return": "off",
+    "no-else-return": "error",
     // disallow use of empty functions
     "no-empty-function": "off",
     // disallow use of empty destructuring patterns
@@ -49,15 +49,15 @@ module.exports = {
     // disallow unnecessary function binding
     "no-extra-bind": "error",
     // disallow unnecessary labels
-    "no-extra-label": "off",
+    "no-extra-label": "error",
     // disallow fallthrough of case statements
     "no-fallthrough": "error",
     // disallow the use of leading or trailing decimal points in numeric literals
-    "no-floating-decimal": "off",
+    "no-floating-decimal": "error",
     // disallow assignments to native objects or read-only global variables
     "no-global-assign": "off",
     // disallow the type conversions with shorter notations
-    "no-implicit-coercion": "off",
+    "no-implicit-coercion": ["error", { "allow": [ "!!" ] }],
     // disallow var and named functions in global scope
     "no-implicit-globals": "off",
     // disallow use of eval()-like methods
@@ -116,7 +116,7 @@ module.exports = {
     // disallow usage of expressions in statement position
     "no-unused-expressions": "error",
     // disallow unused labels
-    "no-unused-labels": "off",
+    "no-unused-labels": "error",
     // disallow unnecessary .call() and .apply()
     "no-useless-call": "error",
     // disallow unnecessary concatenation of literals or template literals
@@ -124,7 +124,7 @@ module.exports = {
     // disallow unnecessary usage of escape character
     "no-useless-escape": "off",
     // disallow redundant return statements
-    "no-useless-return": "off",
+    "no-useless-return": "error",
     // disallow use of void operator
     "no-void": "off",
     // disallow usage of configurable warning terms in comments: e.g. todo
@@ -140,7 +140,7 @@ module.exports = {
     // requires to declare all vars on top of their containing scope
     "vars-on-top": "off",
     // require immediate function invocation to be wrapped in parentheses
-    "wrap-iife": "off",
+    "wrap-iife": ["error", "inside"],
     // require or disallow Yoda conditions
     "yoda": ["error", "never"]
   }

--- a/rules/eslint/es6/on.js
+++ b/rules/eslint/es6/on.js
@@ -3,7 +3,7 @@
 module.exports = {
   "rules": {
     // require braces in arrow function body
-    "arrow-body-style": "off",
+    "arrow-body-style": ["error", "as-needed"],
     // require parens in arrow function arguments
     "arrow-parens": "error",
     // require space before/after arrow function's arrow
@@ -29,11 +29,11 @@ module.exports = {
     // disallow to use this/super before super() calling in constructors.
     "no-this-before-super": "error",
     // disallow unnecessary computed property keys in object literals
-    "no-useless-computed-key": "off",
+    "no-useless-computed-key": "error",
     // disallow unnecessary constructor
     "no-useless-constructor": "off",
     // disallow renaming import, export, and destructured assignments to the same name
-    "no-useless-rename": "off",
+    "no-useless-rename": "error",
     // require let or const instead of var
     "no-var": "error",
     // require method and property shorthand syntax for object literals
@@ -45,7 +45,7 @@ module.exports = {
     // require destructuring from arrays and/or objects
     "prefer-destructuring": "off",
     // disallow parseInt() in favor of binary, octal, and hexadecimal literals
-    "prefer-numeric-literals": "off",
+    "prefer-numeric-literals": "error",
     // suggest using the rest parameters instead of arguments
     "prefer-rest-params": "off",
     // suggest using the spread operator instead of .apply()
@@ -55,14 +55,14 @@ module.exports = {
     // disallow generator functions that do not have yield
     "require-yield": "error",
     // enforce spacing between rest and spread operators and their expressions
-    "rest-spread-spacing": "off",
+    "rest-spread-spacing": "error",
     // enforce sorted import declarations within modules
     "sort-imports": "off",
     // require symbol descriptions
     "symbol-description": "off",
     // enforce spacing around embedded expressions of template strings
-    "template-curly-spacing": "off",
+    "template-curly-spacing": "error",
     // enforce spacing around the * in yield* expressions
-    "yield-star-spacing": "off"
+    "yield-star-spacing": ["error", "after"]
   }
 };


### PR DESCRIPTION
This is the first PR in the updates mentioned in #35.

This PR turns on (almost) all non-style rules in ESLint that are auto-fixable. There are a lot of new rules but with the new `--fix` command, this should be a painless change

http://eslint.org/docs/rules

@kylecesmat @ryan-roemer 