### PR TITLE
[MAJOR] Enable all fixable style rules

### DIFF
--- a/configurations/es5-browser.js
+++ b/configurations/es5-browser.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   "extends": "formidable/configurations/es5",
-  "env": {
-    "browser": true
+  env: {
+    browser: true
   }
 };

--- a/configurations/es5-node.js
+++ b/configurations/es5-node.js
@@ -5,10 +5,10 @@ module.exports = {
     "formidable/configurations/es5",
     "formidable/rules/eslint/node/on"
   ],
-  "env": {
-    "node": true
+  env: {
+    node: true
   },
-  "rules": {
-    "strict": ["error", "global"]
+  rules: {
+    strict: ["error", "global"]
   }
 };

--- a/configurations/es5-test.js
+++ b/configurations/es5-test.js
@@ -4,15 +4,15 @@ module.exports = {
   "extends": [
     "formidable/configurations/es5"
   ],
-  "env": {
-    "mocha": true,
-    "phantomjs": true
+  env: {
+    mocha: true,
+    phantomjs: true
   },
-  "globals": {
-    "expect": true,
-    "sandbox": true
+  globals: {
+    expect: true,
+    sandbox: true
   },
-  "rules": {
+  rules: {
     "max-nested-callbacks": "off",
     "no-unused-expressions": "off"
   }

--- a/configurations/es5.js
+++ b/configurations/es5.js
@@ -12,17 +12,17 @@ module.exports = {
     "formidable/rules/filenames/on",
     "formidable/rules/import/on"
   ],
-  "parserOptions": {
-    "ecmaVersion": 5,
-    "sourceType": "script",
-    "ecmaFeatures": {}
+  parserOptions: {
+    ecmaVersion: 5,
+    sourceType: "script",
+    ecmaFeatures: {}
   },
-  "env": {
-    "amd": true
+  env: {
+    amd: true
   },
-  "globals": {
-    "module": false,
-    "process": false
+  globals: {
+    module: false,
+    process: false
   },
-  "rules": {}
+  rules: {}
 };

--- a/configurations/es6-browser.js
+++ b/configurations/es6-browser.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   "extends": "formidable/configurations/es6",
-  "env": {
-    "browser": true
+  env: {
+    browser: true
   }
 };

--- a/configurations/es6-node-test.js
+++ b/configurations/es6-node-test.js
@@ -4,15 +4,15 @@ module.exports = {
   "extends": [
     "formidable/configurations/es6-node"
   ],
-  "env": {
-    "mocha": true,
-    "phantomjs": true
+  env: {
+    mocha: true,
+    phantomjs: true
   },
-  "globals": {
-    "expect": true,
-    "sandbox": true
+  globals: {
+    expect: true,
+    sandbox: true
   },
-  "rules": {
+  rules: {
     "max-nested-callbacks": "off",
     "no-unused-expressions": "off"
   }

--- a/configurations/es6-node.js
+++ b/configurations/es6-node.js
@@ -5,17 +5,17 @@ module.exports = {
     "formidable/configurations/es6",
     "formidable/rules/eslint/node/on"
   ],
-  "env": {
-    "node": true
+  env: {
+    node: true
   },
-  "parserOptions": {
-    "sourceType": "script",
-    "ecmaFeatures": {
-      "impliedStrict": false
+  parserOptions: {
+    sourceType: "script",
+    ecmaFeatures: {
+      impliedStrict: false
     }
   },
-  "globals": {},
-  "rules": {
+  globals: {},
+  rules: {
     // verify super() callings in constructors
     "constructor-super": "off",
     // disallow modifying variables of class declarations
@@ -25,6 +25,6 @@ module.exports = {
     // disallow to use this/super before super() calling in constructors.
     "no-this-before-super": "off",
     // require that all functions are run in strict mode
-    "strict": ["error", "global"]
+    strict: ["error", "global"]
   }
 };

--- a/configurations/es6-react-test.js
+++ b/configurations/es6-react-test.js
@@ -4,15 +4,15 @@ module.exports = {
   "extends": [
     "formidable/configurations/es6-react"
   ],
-  "env": {
-    "mocha": true,
-    "phantomjs": true
+  env: {
+    mocha: true,
+    phantomjs: true
   },
-  "globals": {
-    "expect": true,
-    "sandbox": true
+  globals: {
+    expect: true,
+    sandbox: true
   },
-  "rules": {
+  rules: {
     "max-nested-callbacks": "off",
     "no-unused-expressions": "off"
   }

--- a/configurations/es6-react.js
+++ b/configurations/es6-react.js
@@ -1,20 +1,20 @@
 "use strict";
 
 module.exports = {
-  "parser": "babel-eslint",
+  parser: "babel-eslint",
   "extends": [
     "formidable/configurations/es6-browser",
     "formidable/rules/react/on"
   ],
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
     }
   },
-  "globals": {
-    "fetch": false
+  globals: {
+    fetch: false
   },
-  "rules": {
+  rules: {
     "no-extra-parens": "off",
     "no-var": "error"
   }

--- a/configurations/es6-test.js
+++ b/configurations/es6-test.js
@@ -4,15 +4,15 @@ module.exports = {
   "extends": [
     "formidable/configurations/es6"
   ],
-  "env": {
-    "mocha": true,
-    "phantomjs": true
+  env: {
+    mocha: true,
+    phantomjs: true
   },
-  "globals": {
-    "expect": true,
-    "sandbox": true
+  globals: {
+    expect: true,
+    sandbox: true
   },
-  "rules": {
+  rules: {
     "max-nested-callbacks": "off",
     "no-unused-expressions": "off"
   }

--- a/configurations/es6.js
+++ b/configurations/es6.js
@@ -5,18 +5,18 @@ module.exports = {
     "formidable/configurations/es5",
     "formidable/rules/eslint/es6/on"
   ],
-  "parser": "babel-eslint",
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module",
-    "ecmaFeatures": {
-      "experimentalObjectRestSpread": true,
-      "impliedStrict": true
+  parser: "babel-eslint",
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: "module",
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      impliedStrict: true
     }
   },
-  "env": {
-    "es6": true
+  env: {
+    es6: true
   },
-  "globals": {},
-  "rules": {}
+  globals: {},
+  rules: {}
 };

--- a/configurations/off.js
+++ b/configurations/off.js
@@ -10,12 +10,12 @@ module.exports = {
     "formidable/rules/eslint/style/off",
     "formidable/rules/eslint/variables/off"
   ],
-  "parserOptions": {
-    "ecmaVersion": 5,
-    "sourceType": "script",
-    "ecmaFeatures": {}
+  parserOptions: {
+    ecmaVersion: 5,
+    sourceType: "script",
+    ecmaFeatures: {}
   },
-  "env": {},
-  "globals": {},
-  "rules": {}
+  env: {},
+  globals: {},
+  rules: {}
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "main": "configurations/es6.js",
   "scripts": {
+    "fix": "eslint configurations rules --fix",
     "test": "eslint configurations rules"
   },
   "engines": {

--- a/rules/eslint/best-practices/off.js
+++ b/rules/eslint/best-practices/off.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // Enforces getter/setter pairs in objects
     "accessor-pairs": "off",
     // enforce return statements in callbacks of array’s methods
@@ -11,11 +11,11 @@ module.exports = {
     // enforce that class methods utilize this
     "class-methods-use-this": "off",
     // specify the maximum cyclomatic complexity allowed in a program
-    "complexity": "off",
+    complexity: "off",
     // require return statements to either always or never specify values
     "consistent-return": "off",
     // specify curly brace conventions for all control statements
-    "curly": "off",
+    curly: "off",
     // require default case in switch statements
     "default-case": "off",
     // enforces consistent newlines before or after dots
@@ -23,7 +23,7 @@ module.exports = {
     // encourages use of dot notation whenever possible
     "dot-notation": "off",
     // require the use of === and !==
-    "eqeqeq": "off",
+    eqeqeq: "off",
     // make sure for-in loops have an if statement
     "guard-for-in": "off",
     // disallow the use of alert, confirm, and prompt
@@ -134,7 +134,7 @@ module.exports = {
     // require using Error objects as Promise rejection reasons
     "prefer-promise-reject-errors": "off",
     // require use of the second argument for parseInt()
-    "radix": "off",
+    radix: "off",
     // disallow async functions which have no await expression
     "require-await": "off",
     // requires to declare all vars on top of their containing scope
@@ -142,6 +142,6 @@ module.exports = {
     // require immediate function invocation to be wrapped in parentheses
     "wrap-iife": "off",
     // require or disallow Yoda conditions
-    "yoda": "off"
+    yoda: "off"
   }
 };

--- a/rules/eslint/best-practices/on.js
+++ b/rules/eslint/best-practices/on.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // Enforces getter/setter pairs in objects
     "accessor-pairs": "off",
     // enforce return statements in callbacks of array’s methods
@@ -11,19 +11,19 @@ module.exports = {
     // enforce that class methods utilize this
     "class-methods-use-this": "off",
     // specify the maximum cyclomatic complexity allowed in a program
-    "complexity": ["error", 11],
+    complexity: ["error", 11],
     // require return statements to either always or never specify values
     "consistent-return": "error",
     // specify curly brace conventions for all control statements
-    "curly": ["error", "all"],
+    curly: ["error", "all"],
     // require default case in switch statements
     "default-case": "off",
     // enforces consistent newlines before or after dots
     "dot-location": ["error", "property"],
     // encourages use of dot notation whenever possible
-    "dot-notation": ["error", { "allowKeywords": true }],
+    "dot-notation": ["error", { allowKeywords: true }],
     // require the use of === and !==
-    "eqeqeq": "error",
+    eqeqeq: "error",
     // make sure for-in loops have an if statement
     "guard-for-in": "off",
     // disallow the use of alert, confirm, and prompt
@@ -57,7 +57,7 @@ module.exports = {
     // disallow assignments to native objects or read-only global variables
     "no-global-assign": "off",
     // disallow the type conversions with shorter notations
-    "no-implicit-coercion": ["error", { "allow": [ "!!" ] }],
+    "no-implicit-coercion": ["error", { allow: ["!!"] }],
     // disallow var and named functions in global scope
     "no-implicit-globals": "off",
     // disallow use of eval()-like methods
@@ -67,13 +67,14 @@ module.exports = {
     // disallow usage of __iterator__ property
     "no-iterator": "error",
     // disallow use of labeled statements
-    "no-labels": ["error", { "allowLoop": true, "allowSwitch": true }],
+    "no-labels": ["error", { allowLoop: true,
+      allowSwitch: true }],
     // disallow unnecessary nested blocks
     "no-lone-blocks": "error",
     // disallow creation of functions within loops
     "no-loop-func": "error",
     // disallow the use of magic numbers
-    "no-magic-numbers": ["error", { "ignore": [-1, 0, 1] }],
+    "no-magic-numbers": ["error", { ignore: [-1, 0, 1] }],
     // disallow use of multiple spaces
     "no-multi-spaces": "error",
     // disallow use of multiline strings
@@ -134,7 +135,7 @@ module.exports = {
     // require using Error objects as Promise rejection reasons
     "prefer-promise-reject-errors": "off",
     // require use of the second argument for parseInt()
-    "radix": "off",
+    radix: "off",
     // disallow async functions which have no await expression
     "require-await": "off",
     // requires to declare all vars on top of their containing scope
@@ -142,6 +143,6 @@ module.exports = {
     // require immediate function invocation to be wrapped in parentheses
     "wrap-iife": ["error", "inside"],
     // require or disallow Yoda conditions
-    "yoda": ["error", "never"]
+    yoda: ["error", "never"]
   }
 };

--- a/rules/eslint/errors/off.js
+++ b/rules/eslint/errors/off.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // disallow await inside of loops
     "no-await-in-loop": "off",
     // disallow comparing against -0

--- a/rules/eslint/errors/on.js
+++ b/rules/eslint/errors/on.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // disallow await inside of loops
     "no-await-in-loop": "off",
     // disallow comparing against -0

--- a/rules/eslint/es6/off.js
+++ b/rules/eslint/es6/off.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // require braces in arrow function body
     "arrow-body-style": "off",
     // require parens in arrow function arguments

--- a/rules/eslint/es6/on.js
+++ b/rules/eslint/es6/on.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // require braces in arrow function body
     "arrow-body-style": ["error", "as-needed"],
     // require parens in arrow function arguments

--- a/rules/eslint/node/off.js
+++ b/rules/eslint/node/off.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // enforce return after a callback
     "callback-return": "off",
     // disallow require() outside of the top-level module scope

--- a/rules/eslint/node/on.js
+++ b/rules/eslint/node/on.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // enforce return after a callback
     "callback-return": "error",
     // disallow require() outside of the top-level module scope

--- a/rules/eslint/strict/off.js
+++ b/rules/eslint/strict/off.js
@@ -1,8 +1,8 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // require that all functions are run in strict mode
-    "strict": "off"
+    strict: "off"
   }
 };

--- a/rules/eslint/strict/on.js
+++ b/rules/eslint/strict/on.js
@@ -1,8 +1,8 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // require that all functions are run in strict mode
-    "strict": ["error", "never"]
+    strict: ["error", "never"]
   }
 };

--- a/rules/eslint/style/off.js
+++ b/rules/eslint/style/off.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // enforce spacing inside array brackets
     "array-bracket-spacing": "off",
     // disallow or enforce spaces inside of single line blocks
@@ -9,7 +9,7 @@ module.exports = {
     // enforce one true brace style
     "brace-style": "off",
     // require camel case names
-    "camelcase": "off",
+    camelcase: "off",
     // enforce or disallow capitalization of the first letter of a comment
     "capitalized-comments": "off",
     // disallow trailing commas in object literals
@@ -39,7 +39,7 @@ module.exports = {
     // require identifiers to match the provided regular expression
     "id-match": "off",
     // this option sets a specific tab width for your code
-    "indent": "off",
+    indent: "off",
     // specify whether double or single quotes should be used in JSX attributes
     "jsx-quotes": "off",
     // enforces spacing between keys and values in object literal properties
@@ -141,11 +141,11 @@ module.exports = {
     // require quotes around object literal property names
     "quote-props": "off",
     // specify whether double or single quotes should be used
-    "quotes": "off",
+    quotes: "off",
     // Require JSDoc comment
     "require-jsdoc": "off",
     // require or disallow use of semicolons instead of ASI
-    "semi": "off",
+    semi: "off",
     // enforce spacing before and after semicolons
     "semi-spacing": "off",
     // require object keys to be sorted

--- a/rules/eslint/style/on.js
+++ b/rules/eslint/style/on.js
@@ -1,15 +1,15 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // enforce spacing inside array brackets
     "array-bracket-spacing": ["error", "never"],
     // disallow or enforce spaces inside of single line blocks
     "block-spacing": ["error", "always"],
     // enforce one true brace style
-    "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
+    "brace-style": ["error", "1tbs", { allowSingleLine: true }],
     // require camel case names
-    "camelcase": "error",
+    camelcase: "error",
     // enforce or disallow capitalization of the first letter of a comment
     "capitalized-comments": "off",
     // disallow trailing commas in object literals
@@ -39,13 +39,15 @@ module.exports = {
     // require identifiers to match the provided regular expression
     "id-match": "off",
     // this option sets a specific tab width for your code
-    "indent": ["error", 2],
+    indent: ["error", 2],
     // specify whether double or single quotes should be used in JSX attributes
     "jsx-quotes": ["error", "prefer-double"],
     // enforces spacing between keys and values in object literal properties
-    "key-spacing": ["error", { "beforeColon": false, "afterColon": true }],
+    "key-spacing": ["error", { beforeColon: false,
+      afterColon: true }],
     // enforce spacing before and after keywords
-    "keyword-spacing": ["error", { "before": true, "after": true }],
+    "keyword-spacing": ["error", { before: true,
+      after: true }],
     // enforce position of line comments
     "line-comment-position": "off",
     // disallow mixed "LF" and "CRLF" as linebreaks
@@ -57,7 +59,8 @@ module.exports = {
     // specify the maximum depth that blocks can be nested
     "max-depth": ["error", 4],
     // specify the maximum length of a line in your program
-    "max-len": ["error", 100, 2, { "ignoreUrls": true, "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(" }],
+    "max-len": ["error", 100, 2, { ignoreUrls: true,
+      ignorePattern: "^\\s*var\\s.+=\\s*require\\s*\\(" }],
     // enforce a maximum number of lines per file
     "max-lines": "off",
     // specify the maximum depth callbacks can be nested
@@ -97,7 +100,7 @@ module.exports = {
     // disallow use of chained assignment expressions
     "no-multi-assign": "off",
     // disallow multiple empty lines
-    "no-multiple-empty-lines": ["error", { "max": 2 }],
+    "no-multiple-empty-lines": ["error", { max: 2 }],
     // disallow negated conditions
     "no-negated-condition": "off",
     // disallow nested ternary expressions
@@ -139,15 +142,17 @@ module.exports = {
     // enforce padding within blocks
     "padded-blocks": ["error", "never"],
     // require quotes around object literal property names
-    "quote-props": ["error", "as-needed", { "keywords": true, "numbers": true }],
+    "quote-props": ["error", "as-needed", { keywords: true,
+      numbers: true }],
     // specify whether double or single quotes should be used
-    "quotes": ["error", "double"],
+    quotes: ["error", "double"],
     // Require JSDoc comment
     "require-jsdoc": "off",
     // require or disallow use of semicolons instead of ASI
-    "semi": "error",
+    semi: "error",
     // enforce spacing before and after semicolons
-    "semi-spacing": ["error", { "before": false, "after": true }],
+    "semi-spacing": ["error", { before: false,
+      after: true }],
     // require object keys to be sorted
     "sort-keys": "off",
     // sort variables within the same declaration block
@@ -155,15 +160,17 @@ module.exports = {
     // require or disallow space before blocks
     "space-before-blocks": ["error", "always"],
     // require or disallow space before function opening parenthesis
-    "space-before-function-paren": ["error", { "anonymous": "always", "named": "never" }],
+    "space-before-function-paren": ["error", { anonymous: "always",
+      named: "never" }],
     // require or disallow spaces inside parentheses
     "space-in-parens": ["error", "never"],
     // require spaces around operators
     "space-infix-ops": "error",
     // Require or disallow spaces before/after unary operators
-    "space-unary-ops": ["error", { "words": true, "nonwords": false }],
+    "space-unary-ops": ["error", { words: true,
+      nonwords: false }],
     // require or disallow a space immediately following the // or /* in a comment
-    "spaced-comment": ["error", "always", { "exceptions": ["-", "=", "*"] }],
+    "spaced-comment": ["error", "always", { exceptions: ["-", "=", "*"] }],
     // require or disallow spacing between template tags and their literals
     "template-tag-spacing": ["error", "always"],
     // require or disallow Unicode byte order mark (BOM)

--- a/rules/eslint/style/on.js
+++ b/rules/eslint/style/on.js
@@ -3,9 +3,9 @@
 module.exports = {
   "rules": {
     // enforce spacing inside array brackets
-    "array-bracket-spacing": "off",
+    "array-bracket-spacing": ["error", "never"],
     // disallow or enforce spaces inside of single line blocks
-    "block-spacing": "off",
+    "block-spacing": ["error", "always"],
     // enforce one true brace style
     "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
     // require camel case names
@@ -25,7 +25,7 @@ module.exports = {
     // enforce newline at the end of file, with no multiple empty lines
     "eol-last": "error",
     // require or disallow spacing between function identifiers and their invocations
-    "func-call-spacing": "off",
+    "func-call-spacing": ["error", "never"],
     // require function names to match the name of the variable or property to which they are assigned
     "func-name-matching": "off",
     // require function expressions to have a name
@@ -53,7 +53,7 @@ module.exports = {
     // enforces empty lines around comments
     "lines-around-comment": "off",
     // require or disallow newlines around directives
-    "lines-around-directive": "off",
+    "lines-around-directive": ["error", "always"],
     // specify the maximum depth that blocks can be nested
     "max-depth": ["error", 4],
     // specify the maximum length of a line in your program
@@ -117,29 +117,29 @@ module.exports = {
     // disallow dangling underscores in identifiers
     "no-underscore-dangle": "off",
     // disallow the use of Boolean literals in conditional expressions
-    "no-unneeded-ternary": "off",
+    "no-unneeded-ternary": "error",
     // disallow whitespace before properties
-    "no-whitespace-before-property": "off",
+    "no-whitespace-before-property": "error",
     // enforce the location of single-line statements
-    "nonblock-statement-body-position": "off",
+    "nonblock-statement-body-position": ["error", "below"],
     // enforce consistent line breaks inside braces
     "object-curly-newline": "off",
     // require or disallow padding inside curly braces
     "object-curly-spacing": ["error", "always"],
     // enforce placing object properties on separate lines
-    "object-property-newline": "off",
+    "object-property-newline": "error",
     // allow just one var statement per function
     "one-var": ["error", "never"],
     // require or disallow an newline around variable declarations
-    "one-var-declaration-per-line": "off",
+    "one-var-declaration-per-line": ["error", "initializations"],
     // require assignment operator shorthand where possible or prohibit it entirely
     "operator-assignment": ["error", "always"],
     // enforce operators to be placed before or after line breaks
-    "operator-linebreak": "off",
+    "operator-linebreak": ["error", "before"],
     // enforce padding within blocks
-    "padded-blocks": "off",
+    "padded-blocks": ["error", "never"],
     // require quotes around object literal property names
-    "quote-props": "off",
+    "quote-props": ["error", "as-needed", { "keywords": true, "numbers": true }],
     // specify whether double or single quotes should be used
     "quotes": ["error", "double"],
     // Require JSDoc comment
@@ -163,8 +163,12 @@ module.exports = {
     // Require or disallow spaces before/after unary operators
     "space-unary-ops": ["error", { "words": true, "nonwords": false }],
     // require or disallow a space immediately following the // or /* in a comment
-    "spaced-comment": "off",
+    "spaced-comment": ["error", "always", { "exceptions": ["-", "=", "*"] }],
+    // require or disallow spacing between template tags and their literals
+    "template-tag-spacing": ["error", "always"],
+    // require or disallow Unicode byte order mark (BOM)
+    "unicode-bom": "off",
     // require regex literals to be wrapped in parentheses
-    "wrap-regex": "off"
+    "wrap-regex": "error"
   }
 };

--- a/rules/eslint/variables/off.js
+++ b/rules/eslint/variables/off.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // enforce or disallow variable initializations at definition
     "init-declarations": "off",
     // disallow the catch clause parameter name being the same as a variable in the outer scope

--- a/rules/eslint/variables/on.js
+++ b/rules/eslint/variables/on.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  "rules": {
+  rules: {
     // enforce or disallow variable initializations at definition
     "init-declarations": "off",
     // disallow the catch clause parameter name being the same as a variable in the outer scope
@@ -23,7 +23,8 @@ module.exports = {
     // disallow use of undefined variable
     "no-undefined": "off",
     // disallow declaration of variables that are not used in the code
-    "no-unused-vars": ["error", { "vars": "all", "args": "after-used" }],
+    "no-unused-vars": ["error", { vars: "all",
+      args: "after-used" }],
     // disallow use of variables before they are defined
     "no-use-before-define": "error"
   }

--- a/rules/filenames/off.js
+++ b/rules/filenames/off.js
@@ -1,10 +1,10 @@
 "use strict";
 
 module.exports = {
-  "plugins": [
+  plugins: [
     "filenames"
   ],
-  "rules": {
+  rules: {
     // Enforce dash-cased filenames
     "filenames/match-regex": "off",
     // Match the file name against the default exported value in the module

--- a/rules/filenames/on.js
+++ b/rules/filenames/on.js
@@ -1,10 +1,10 @@
 "use strict";
 
 module.exports = {
-  "plugins": [
+  plugins: [
     "filenames"
   ],
-  "rules": {
+  rules: {
     // Enforce dash-cased filenames
     // `true` here means "don't enforce if `export default` exists in file"
     "filenames/match-regex": ["error", "^[a-z0-9\\-\\.]+$", false],

--- a/rules/import/off.js
+++ b/rules/import/off.js
@@ -1,51 +1,51 @@
 "use strict";
 
 module.exports = {
-  "plugins": [
+  plugins: [
     "import"
   ],
-  "rules": {
+  rules: {
     // Ensure imports point to a file/module that can be resolved
     "import/no-unresolved": "off",
-    //Ensure named imports correspond to a named export in the remote file
+    // Ensure named imports correspond to a named export in the remote file
     "import/named": "off",
     // Ensure a default export is present, given a default import
     "import/default": "off",
-    //Ensure imported namespaces contain dereferenced properties as they are dereferenced
+    // Ensure imported namespaces contain dereferenced properties as they are dereferenced
     "import/namespace": "off",
-    //Restrict which files can be imported in a given folder
+    // Restrict which files can be imported in a given folder
     "import/no-restricted-paths": "off",
     // Report any invalid exports, i.e. re-export of the same name
     "import/export": "off",
-    //Report use of exported name as identifier of default export
+    // Report use of exported name as identifier of default export
     "import/no-named-as-default": "off",
-    //Report use of exported name as property of default export
+    // Report use of exported name as property of default export
     "import/no-named-as-default-member": "off",
-    //Report imported names marked with @deprecated documentation tag
+    // Report imported names marked with @deprecated documentation tag
     "import/no-deprecated": "off",
     // Forbid the use of extraneous packages
     "import/no-extraneous-dependencies": "off",
     // Forbid the use of mutable exports with var or let
     "import/no-mutable-exports": "off",
-    //Report CommonJS require calls and module.exports or exports.*
+    // Report CommonJS require calls and module.exports or exports.*
     "import/no-commonjs": "off",
-    //Report AMD require and define calls.
+    // Report AMD require and define calls.
     "import/no-amd": "off",
-    //No Node.js builtin modules
+    // No Node.js builtin modules
     "import/no-nodejs-modules": "off",
     // Ensure all imports appear before other statements
     "import/imports-first": "off",
     // Report repeated import of the same module in multiple places
     "import/no-duplicates": "off",
-    //Report namespace imports
+    // Report namespace imports
     "import/no-namespace": "off",
-    //Ensure consistent use of file extension within the import path
+    // Ensure consistent use of file extension within the import path
     "import/extensions": "off",
-    //Enforce a convention in module import order
+    // Enforce a convention in module import order
     "import/order": "off",
-    //Enforce a newline after import statements
+    // Enforce a newline after import statements
     "import/newline-after-import": "off",
-    //Prefer a default export if module exports a single name
+    // Prefer a default export if module exports a single name
     "import/prefer-default-export": "off"
   }
 };

--- a/rules/import/on.js
+++ b/rules/import/on.js
@@ -1,51 +1,51 @@
 "use strict";
 
 module.exports = {
-  "plugins": [
+  plugins: [
     "import"
   ],
-  "rules": {
+  rules: {
     // Ensure imports point to a file/module that can be resolved
     "import/no-unresolved": "error",
-    //Ensure named imports correspond to a named export in the remote file
+    // Ensure named imports correspond to a named export in the remote file
     "import/named": "off",
     // Ensure a default export is present, given a default import
     "import/default": "off",
-    //Ensure imported namespaces contain dereferenced properties as they are dereferenced
+    // Ensure imported namespaces contain dereferenced properties as they are dereferenced
     "import/namespace": "off",
-    //Restrict which files can be imported in a given folder
+    // Restrict which files can be imported in a given folder
     "import/no-restricted-paths": "off",
     // Report any invalid exports, i.e. re-export of the same name
     "import/export": "error",
-    //Report use of exported name as identifier of default export
+    // Report use of exported name as identifier of default export
     "import/no-named-as-default": "off",
-    //Report use of exported name as property of default export
+    // Report use of exported name as property of default export
     "import/no-named-as-default-member": "off",
-    //Report imported names marked with @deprecated documentation tag
+    // Report imported names marked with @deprecated documentation tag
     "import/no-deprecated": "off",
     // Forbid the use of extraneous packages
     "import/no-extraneous-dependencies": "off",
     // Forbid the use of mutable exports with var or let
     "import/no-mutable-exports": "error",
-    //Report CommonJS require calls and module.exports or exports.*
+    // Report CommonJS require calls and module.exports or exports.*
     "import/no-commonjs": "off",
-    //Report AMD require and define calls.
+    // Report AMD require and define calls.
     "import/no-amd": "off",
-    //No Node.js builtin modules
+    // No Node.js builtin modules
     "import/no-nodejs-modules": "off",
     // Ensure all imports appear before other statements
     "import/imports-first": "error",
     // Report repeated import of the same module in multiple places
     "import/no-duplicates": "error",
-    //Report namespace imports
+    // Report namespace imports
     "import/no-namespace": "off",
-    //Ensure consistent use of file extension within the import path
+    // Ensure consistent use of file extension within the import path
     "import/extensions": "off",
-    //Enforce a convention in module import order
+    // Enforce a convention in module import order
     "import/order": "off",
-    //Enforce a newline after import statements
+    // Enforce a newline after import statements
     "import/newline-after-import": "off",
-    //Prefer a default export if module exports a single name
+    // Prefer a default export if module exports a single name
     "import/prefer-default-export": "off"
   }
 };

--- a/rules/react/off.js
+++ b/rules/react/off.js
@@ -1,10 +1,10 @@
 "use strict";
 
 module.exports = {
-  "plugins": [
+  plugins: [
     "react"
   ],
-  "rules": {
+  rules: {
     // Prevent missing displayName in a React component definition
     "react/display-name": "off",
     // Forbid certain propTypes

--- a/rules/react/on.js
+++ b/rules/react/on.js
@@ -1,10 +1,10 @@
 "use strict";
 
 module.exports = {
-  "plugins": [
+  plugins: [
     "react"
   ],
-  "rules": {
+  rules: {
     // Prevent missing displayName in a React component definition
     "react/display-name": "off",
     // Forbid certain propTypes


### PR DESCRIPTION
This is the second PR in the updates mentioned in #35.

This PR turns on (almost) all style rules in ESLint that are auto-fixable. There are a lot of new rules but with the new --fix command, this should be a painless change

http://eslint.org/docs/rules

@kylecesmat @ryan-roemer