### PR TITLE
add Jest to test configurations

### DIFF
--- a/configurations/es5-test.js
+++ b/configurations/es5-test.js
@@ -6,6 +6,7 @@ module.exports = {
   ],
   env: {
     mocha: true,
+    jest: true,
     phantomjs: true
   },
   globals: {

--- a/configurations/es6-node-test.js
+++ b/configurations/es6-node-test.js
@@ -6,6 +6,7 @@ module.exports = {
   ],
   env: {
     mocha: true,
+    jest: true,
     phantomjs: true
   },
   globals: {

--- a/configurations/es6-react-test.js
+++ b/configurations/es6-react-test.js
@@ -6,6 +6,7 @@ module.exports = {
   ],
   env: {
     mocha: true,
+    jest: true,
     phantomjs: true
   },
   globals: {

--- a/configurations/es6-test.js
+++ b/configurations/es6-test.js
@@ -6,6 +6,7 @@ module.exports = {
   ],
   env: {
     mocha: true,
+    jest: true,
     phantomjs: true
   },
   globals: {


### PR DESCRIPTION
Jest primarily uses Mocha globals, but there are a few unique ones (like `jest` itself: [Mock Function API](https://facebook.github.io/jest/docs/en/mock-function-api.html)).

While we're at it, are there other test global envs we want? [ESLint: Specifying Environments](https://eslint.org/docs/user-guide/configuring#specifying-environments). Maybe jasmine?