### PR TITLE
Improvements to promise and import and return rules

### DIFF
--- a/configurations/es5.js
+++ b/configurations/es5.js
@@ -10,7 +10,8 @@ module.exports = {
     "formidable/rules/eslint/style/on",
     "formidable/rules/eslint/variables/on",
     "formidable/rules/filenames/on",
-    "formidable/rules/import/on"
+    "formidable/rules/import/on",
+    "formidable/rules/promise/on"
   ],
   parserOptions: {
     ecmaVersion: 5,

--- a/configurations/off.js
+++ b/configurations/off.js
@@ -8,7 +8,10 @@ module.exports = {
     "formidable/rules/eslint/node/off",
     "formidable/rules/eslint/strict/off",
     "formidable/rules/eslint/style/off",
-    "formidable/rules/eslint/variables/off"
+    "formidable/rules/eslint/variables/off",
+    "formidable/rules/filenames/off",
+    "formidable/rules/import/off",
+    "formidable/rules/promise/off"
   ],
   parserOptions: {
     ecmaVersion: 5,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint": "3.19.0",
     "eslint-plugin-filenames": "1.1.0",
     "eslint-plugin-import": "1.13.0",
+    "eslint-plugin-promise": "3.7.0",
     "eslint-plugin-react": "6.0.0"
   },
   "main": "configurations/es6.js",

--- a/rules/eslint/best-practices/on.js
+++ b/rules/eslint/best-practices/on.js
@@ -13,7 +13,7 @@ module.exports = {
     // specify the maximum cyclomatic complexity allowed in a program
     complexity: ["error", 11],
     // require return statements to either always or never specify values
-    "consistent-return": "error",
+    "consistent-return": ["error", { treatUndefinedAsUnspecified: true }],
     // specify curly brace conventions for all control statements
     curly: ["error", "all"],
     // require default case in switch statements

--- a/rules/import/on.js
+++ b/rules/import/on.js
@@ -6,7 +6,7 @@ module.exports = {
   ],
   rules: {
     // Ensure imports point to a file/module that can be resolved
-    "import/no-unresolved": "error",
+    "import/no-unresolved": ["error", { commonjs: true }],
     // Ensure named imports correspond to a named export in the remote file
     "import/named": "off",
     // Ensure a default export is present, given a default import

--- a/rules/promise/off.js
+++ b/rules/promise/off.js
@@ -1,0 +1,27 @@
+"use strict";
+
+module.exports = {
+  plugins: [
+    "promise"
+  ],
+  rules: {
+    // Return inside each then() to create readable and reusable Promise chains.
+    "promise/always-return": "off",
+    // Avoid creating new promises outside of utility libs (use pify instead)
+    "promise/avoid-new": "off",
+    // Enforces the use of catch() on un-returned promises.
+    "promise/catch-or-return": "off",
+    // Avoid calling cb() inside of a then() (use nodeify instead)
+    "promise/no-callback-in-promise": "off",
+    // In an ES5 environment, make sure to create a Promise constructor before using.
+    "promise/no-native": "off",
+    // Avoid nested then() or catch() statements
+    "promise/no-nesting": "off",
+    // Avoid using promises inside of callbacks
+    "promise/no-promise-in-callback": "off",
+    // Avoid wrapping values in Promise.resolve or Promise.reject when not needed.
+    "promise/no-return-wrap": "off",
+    // Enforce consistent param names when creating new promises.
+    "promise/param-names": "off"
+  }
+};

--- a/rules/promise/on.js
+++ b/rules/promise/on.js
@@ -1,0 +1,27 @@
+"use strict";
+
+module.exports = {
+  plugins: [
+    "promise"
+  ],
+  rules: {
+    // Return inside each then() to create readable and reusable Promise chains.
+    "promise/always-return": "error",
+    // Avoid creating new promises outside of utility libs (use pify instead)
+    "promise/avoid-new": "error",
+    // Enforces the use of catch() on un-returned promises.
+    "promise/catch-or-return": "error",
+    // Avoid calling cb() inside of a then() (use nodeify instead)
+    "promise/no-callback-in-promise": "error",
+    // In an ES5 environment, make sure to create a Promise constructor before using.
+    "promise/no-native": "off",
+    // Avoid nested then() or catch() statements
+    "promise/no-nesting": "error",
+    // Avoid using promises inside of callbacks
+    "promise/no-promise-in-callback": "error",
+    // Avoid wrapping values in Promise.resolve or Promise.reject when not needed.
+    "promise/no-return-wrap": "error",
+    // Enforce consistent param names when creating new promises.
+    "promise/param-names": "error"
+  }
+};


### PR DESCRIPTION
based on current formidable configs, e.g. https://github.com/FormidableLabs/louder-cloud/blob/master/.eslintrc#L10-L21

- add promise rules
- add options to consistent-return and import/no-unresolved
- fix bug in `configurations/off.js` - we forgot to turn off `import` and `filename` rules that `es5.js` turns on